### PR TITLE
Create site skeleton, navigation, and legal pages

### DIFF
--- a/app/404.tsx
+++ b/app/404.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link"
+
+export default function NotFound() {
+  return (
+    <div className="bg-black text-white min-h-screen flex items-center justify-center px-6">
+      <div className="max-w-xl text-center space-y-4">
+        <h1 className="text-4xl font-bold">Page introuvable</h1>
+        <p className="text-white/70">Contenu à venir.</p>
+        <Link className="underline" href="/">
+          Retour à l'accueil
+        </Link>
+      </div>
+    </div>
+  )
+}
+

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Blog",
+  path: "/blog",
+  description: "Contenu à venir.",
+})
+
+export default function BlogPage() {
+  return (
+    <SimplePageLayout
+      title="Blog"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Blog" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Retrouvez toutes nos ressources dans la section <Link className="underline" href="/ressources">Ressources</Link>.
+      </p>
+      <p>
+        Pour toute question, consultez la <Link className="underline" href="/faq">FAQ</Link> ou <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/cas-usage/[slug]/[task]/page.tsx
+++ b/app/cas-usage/[slug]/[task]/page.tsx
@@ -1,0 +1,82 @@
+import { notFound } from "next/navigation"
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import {
+  casUsage,
+  casUsageMap,
+  casUsageTasksMap,
+  servicesMap,
+} from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  const params: { slug: string; task: string }[] = []
+  casUsage.forEach((item) => {
+    casUsageTasksMap.forEach((_task, taskSlug) => {
+      params.push({ slug: item.slug, task: taskSlug })
+    })
+  })
+  return params
+}
+
+export function generateMetadata({ params }: { params: { slug: string; task: string } }) {
+  const casItem = casUsageMap.get(params.slug)
+  const task = casUsageTasksMap.get(params.task)
+
+  if (!casItem || !task) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: `${task.title} - ${casItem.title}`,
+    path: `/cas-usage/${casItem.slug}/${task.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function CasUsageTaskPage({ params }: { params: { slug: string; task: string } }) {
+  const casItem = casUsageMap.get(params.slug)
+  const task = casUsageTasksMap.get(params.task)
+
+  if (!casItem || !task) {
+    notFound()
+  }
+
+  const serviceLinks = casItem.relatedServices
+    .map((slug) => {
+      const item = servicesMap.get(slug)
+      return item ? { href: `/services/${slug}`, label: item.title } : null
+    })
+    .filter(Boolean) as { href: string; label: string }[]
+
+  return (
+    <SimplePageLayout
+      title={`${task.title}`}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Cas d'usage", href: "/cas-usage" },
+        { label: casItem.title, href: `/cas-usage/${casItem.slug}` },
+        { label: task.title },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection title="Services associés" links={serviceLinks} />
+      <LinkSection
+        title="Aller plus loin"
+        links={[
+          { href: `/cas-usage/${casItem.slug}`, label: `Retour : ${casItem.title}` },
+          { href: "/faq", label: "Consulter la FAQ" },
+          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
+        ]}
+      />
+      <p>
+        Besoin d'accompagnement ? <Link className="underline" href="/contact">Contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/cas-usage/[slug]/page.tsx
+++ b/app/cas-usage/[slug]/page.tsx
@@ -1,0 +1,84 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import {
+  casUsage,
+  casUsageMap,
+  casUsageTasks,
+  sectorsMap,
+  servicesMap,
+} from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return casUsage.map((item) => ({ slug: item.slug }))
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  const casItem = casUsageMap.get(params.slug)
+  if (!casItem) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: casItem.title,
+    path: `/cas-usage/${casItem.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function CasUsagePage({ params }: { params: { slug: string } }) {
+  const casItem = casUsageMap.get(params.slug)
+
+  if (!casItem) {
+    notFound()
+  }
+
+  const serviceLinks = casItem.relatedServices
+    .map((slug) => {
+      const item = servicesMap.get(slug)
+      return item ? { href: `/services/${slug}`, label: item.title } : null
+    })
+    .filter(Boolean) as { href: string; label: string }[]
+
+  const sector = sectorsMap.get(casItem.relatedSector)
+
+  const taskLinks = casUsageTasks.map((task) => ({
+    href: `/cas-usage/${casItem.slug}/${task.slug}`,
+    label: task.title,
+  }))
+
+  return (
+    <SimplePageLayout
+      title={casItem.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Cas d'usage", href: "/cas-usage" },
+        { label: casItem.title },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection title="Services associés" links={serviceLinks} />
+      <LinkSection
+        title="Secteur recommandé"
+        links={sector ? [{ href: `/secteurs/${sector.slug}`, label: sector.title }] : []}
+      />
+      <LinkSection title="Parcours et tâches" links={taskLinks} />
+      <LinkSection
+        title="Ressources"
+        links={[
+          { href: "/ressources/guides", label: "Guides" },
+          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
+        ]}
+      />
+      <p>
+        Questions fréquentes ? Consultez la <Link className="underline" href="/faq">FAQ</Link> ou <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/cas-usage/page.tsx
+++ b/app/cas-usage/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link"
+import { createPageMetadata } from "@/lib/metadata"
+import { casUsage, casUsageTasks } from "@/lib/site-structure"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+
+export const metadata = createPageMetadata({
+  title: "Cas d'usage",
+  path: "/cas-usage",
+  description: "Contenu à venir.",
+})
+
+export default function CasUsageIndex() {
+  return (
+    <SimplePageLayout
+      title="Cas d'usage"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Cas d'usage" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {casUsage.map((item) => (
+          <Link
+            key={item.slug}
+            href={`/cas-usage/${item.slug}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {item.title}
+          </Link>
+        ))}
+      </div>
+      <p className="text-sm text-white/60">Sous-pages disponibles : {casUsageTasks.length} tâches.</p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/changelog/page.tsx
+++ b/app/changelog/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Changelog",
+  path: "/changelog",
+  description: "Contenu à venir.",
+})
+
+export default function ChangelogPage() {
+  return (
+    <SimplePageLayout
+      title="Changelog"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Changelog" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Suivre l'état de nos services sur la page <Link className="underline" href="/status">status</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/conditions-generales/page.tsx
+++ b/app/conditions-generales/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Conditions générales",
+  path: "/conditions-generales",
+  description: "Contenu à venir.",
+})
+
+export default function ConditionsGeneralesPage() {
+  return (
+    <SimplePageLayout
+      title="Conditions générales"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Conditions générales" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Voir également nos <Link className="underline" href="/mentions-legales">mentions légales</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/contact/merci/page.tsx
+++ b/app/contact/merci/page.tsx
@@ -1,0 +1,29 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Merci",
+  path: "/contact/merci",
+  description: "Contenu à venir.",
+})
+
+export default function ContactMerciPage() {
+  return (
+    <SimplePageLayout
+      title="Merci"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Contact", href: "/contact" },
+        { label: "Merci" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Retourner à la page <Link className="underline" href="/contact">Contact</Link> ou découvrir nos <Link className="underline" href="/services">services</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Contact",
+  path: "/contact",
+  description: "Contenu à venir.",
+})
+
+export default function ContactPage() {
+  return (
+    <SimplePageLayout
+      title="Contact"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Contact" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Ressources utiles"
+        links={[
+          { href: "/faq", label: "Consulter la FAQ" },
+          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
+        ]}
+      />
+      <p>
+        Après envoi du formulaire, accédez à la page <Link className="underline" href="/contact/merci">merci</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/cookies/page.tsx
+++ b/app/cookies/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Politique cookies",
+  path: "/cookies",
+  description: "Contenu à venir.",
+})
+
+export default function CookiesPage() {
+  return (
+    <SimplePageLayout
+      title="Politique cookies"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Politique cookies" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Gérez vos préférences via le bandeau cookies ou <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/dpa/page.tsx
+++ b/app/dpa/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "DPA",
+  path: "/dpa",
+  description: "Contenu à venir.",
+})
+
+export default function DpaPage() {
+  return (
+    <SimplePageLayout
+      title="DPA"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "DPA" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Consultez également notre <Link className="underline" href="/conditions-generales">conditions générales</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "FAQ",
+  path: "/faq",
+  description: "Contenu à venir.",
+})
+
+export default function FAQPage() {
+  return (
+    <SimplePageLayout
+      title="FAQ"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "FAQ" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Ressources utiles"
+        links={[
+          { href: "/services", label: "Découvrir les services" },
+          { href: "/contact", label: "Nous contacter" },
+        ]}
+      />
+      <p>
+        Explorez aussi le <Link className="underline" href="/ressources/question-hub-ia">Question-Hub IA</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from "next"
 import { Inter, Poppins, JetBrains_Mono } from "next/font/google"
 import "./globals.css"
 import { ParticleProvider } from "@/components/particle-context"
+import { CookieBanner } from "@/components/cookie-banner"
 
 const inter = Inter({
   variable: "--font-inter",
@@ -39,7 +40,10 @@ export default function RootLayout({
         className={`${inter.variable} ${poppins.variable} ${jetbrainsMono.variable} font-poppins antialiased`}
         suppressHydrationWarning
       >
-        <ParticleProvider>{children}</ParticleProvider>
+        <ParticleProvider>
+          {children}
+          <CookieBanner />
+        </ParticleProvider>
       </body>
     </html>
   )

--- a/app/mentions-legales/page.tsx
+++ b/app/mentions-legales/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Mentions légales",
+  path: "/mentions-legales",
+  description: "Contenu à venir.",
+})
+
+export default function MentionsLegalesPage() {
+  return (
+    <SimplePageLayout
+      title="Mentions légales"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Mentions légales" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Pour toute demande, <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/methode/page.tsx
+++ b/app/methode/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Méthode",
+  path: "/methode",
+  description: "Contenu à venir.",
+})
+
+export default function MethodePage() {
+  return (
+    <SimplePageLayout
+      title="Méthode"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Méthode" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Étapes suivantes"
+        links={[
+          { href: "/services", label: "Découvrir les services" },
+          { href: "/contact", label: "Prendre contact" },
+        ]}
+      />
+      <p>
+        Questions ? Consultez la <Link className="underline" href="/faq">FAQ</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -22,6 +22,7 @@ import { Innovation } from "@/components/innovation"
 import { Partnerships } from "@/components/partnerships"
 import { Expertise } from "@/components/expertise"
 import { News } from "@/components/news"
+import { HomeLinks } from "@/components/home-links"
 
 export default function Home() {
   return (
@@ -44,6 +45,7 @@ export default function Home() {
       <Insights />
       <Methodology />
       <Resources />
+      <HomeLinks />
       <News />
       <Contact />
       <Footer />

--- a/app/ressources/calculateur-roi/page.tsx
+++ b/app/ressources/calculateur-roi/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Calculateur ROI",
+  path: "/ressources/calculateur-roi",
+  description: "Contenu à venir.",
+})
+
+export default function CalculateurROIPage() {
+  return (
+    <SimplePageLayout
+      title="Calculateur ROI"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Calculateur ROI" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Actions rapides"
+        links={[
+          { href: "/tarifs", label: "Consulter les tarifs" },
+          { href: "/contact", label: "Contacter l'équipe" },
+        ]}
+      />
+      <p>
+        Besoin d'aide ? Consultez la <Link className="underline" href="/faq">FAQ</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/comparatifs/[category]/[slug]/page.tsx
+++ b/app/ressources/comparatifs/[category]/[slug]/page.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import { comparatifs } from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return comparatifs.map((entry) => ({ category: entry.category, slug: entry.slug }))
+}
+
+export function generateMetadata({ params }: { params: { category: string; slug: string } }) {
+  const entry = comparatifs.find((item) => item.category === params.category && item.slug === params.slug)
+
+  if (!entry) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: entry.title,
+    path: `/ressources/comparatifs/${entry.category}/${entry.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function ComparatifEntryPage({ params }: { params: { category: string; slug: string } }) {
+  const entry = comparatifs.find((item) => item.category === params.category && item.slug === params.slug)
+
+  if (!entry) {
+    notFound()
+  }
+
+  const categoryLabel = entry.category.replace(/-/g, " ")
+  const categoryHref = `/ressources/comparatifs/${entry.category}`
+
+  return (
+    <SimplePageLayout
+      title={entry.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Comparatifs", href: "/ressources/comparatifs" },
+        { label: categoryLabel, href: categoryHref },
+        { label: entry.title },
+      ]}
+    >
+      <p>
+        Voir toutes les comparaisons : <Link className="underline" href={categoryHref}>{categoryLabel}</Link>.
+      </p>
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Ressources connexes"
+        links={[
+          { href: "/tarifs", label: "Consulter les tarifs" },
+          { href: "/faq", label: "Consulter la FAQ" },
+        ]}
+      />
+      <p>
+        Fin du comparatif. Retour à <Link className="underline" href={categoryHref}>{categoryLabel}</Link> ou <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/comparatifs/[category]/page.tsx
+++ b/app/ressources/comparatifs/[category]/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { comparatifs } from "@/lib/site-structure"
+
+const categories = Array.from(new Set(comparatifs.map((entry) => entry.category)))
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return categories.map((category) => ({ category }))
+}
+
+export function generateMetadata({ params }: { params: { category: string } }) {
+  if (!categories.includes(params.category)) {
+    return {}
+  }
+
+  const title = `Comparatifs - ${params.category.replace(/-/g, " ")}`
+
+  return createPageMetadata({
+    title,
+    path: `/ressources/comparatifs/${params.category}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function ComparatifCategoryPage({ params }: { params: { category: string } }) {
+  if (!categories.includes(params.category)) {
+    notFound()
+  }
+
+  const items = comparatifs.filter((entry) => entry.category === params.category)
+
+  return (
+    <SimplePageLayout
+      title={`Comparatifs - ${params.category.replace(/-/g, " ")}`}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Comparatifs", href: "/ressources/comparatifs" },
+        { label: params.category.replace(/-/g, " ") },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {items.map((item) => (
+          <Link
+            key={item.slug}
+            href={`/ressources/comparatifs/${item.category}/${item.slug}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {item.title}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/comparatifs/page.tsx
+++ b/app/ressources/comparatifs/page.tsx
@@ -1,0 +1,40 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { comparatifs } from "@/lib/site-structure"
+
+const categories = Array.from(new Set(comparatifs.map((item) => item.category)))
+
+export const metadata = createPageMetadata({
+  title: "Comparatifs",
+  path: "/ressources/comparatifs",
+  description: "Contenu à venir.",
+})
+
+export default function ComparatifsPage() {
+  return (
+    <SimplePageLayout
+      title="Comparatifs"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Comparatifs" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {categories.map((category) => (
+          <Link
+            key={category}
+            href={`/ressources/comparatifs/${category}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30 uppercase"
+          >
+            {category.replace(/-/g, " ")}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/glossaire/[slug]/page.tsx
+++ b/app/ressources/glossaire/[slug]/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import { glossaire, glossaireMap } from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return glossaire.map((item) => ({ slug: item.slug }))
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  const entry = glossaireMap.get(params.slug)
+  if (!entry) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: entry.title,
+    path: `/ressources/glossaire/${entry.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function GlossaireEntryPage({ params }: { params: { slug: string } }) {
+  const entry = glossaireMap.get(params.slug)
+
+  if (!entry) {
+    notFound()
+  }
+
+  return (
+    <SimplePageLayout
+      title={entry.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Glossaire", href: "/ressources/glossaire" },
+        { label: entry.title },
+      ]}
+    >
+      <p>
+        Retour au <Link className="underline" href="/ressources/glossaire">Glossaire</Link>.
+      </p>
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Ressources associées"
+        links={[
+          { href: "/ressources/guides", label: "Voir les guides" },
+          { href: "/faq", label: "Consulter la FAQ" },
+        ]}
+      />
+      <p>
+        Fin de la définition. Retour au <Link className="underline" href="/ressources/glossaire">Glossaire</Link> ou <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/glossaire/page.tsx
+++ b/app/ressources/glossaire/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { glossaire } from "@/lib/site-structure"
+
+export const metadata = createPageMetadata({
+  title: "Glossaire",
+  path: "/ressources/glossaire",
+  description: "Contenu à venir.",
+})
+
+export default function GlossairePage() {
+  return (
+    <SimplePageLayout
+      title="Glossaire"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Glossaire" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {glossaire.map((item) => (
+          <Link
+            key={item.slug}
+            href={`/ressources/glossaire/${item.slug}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {item.title}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/guides/[slug]/page.tsx
+++ b/app/ressources/guides/[slug]/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import { guides, guidesMap } from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return guides.map((guide) => ({ slug: guide.slug }))
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  const guide = guidesMap.get(params.slug)
+  if (!guide) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: guide.title,
+    path: `/ressources/guides/${guide.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function GuidePage({ params }: { params: { slug: string } }) {
+  const guide = guidesMap.get(params.slug)
+
+  if (!guide) {
+    notFound()
+  }
+
+  return (
+    <SimplePageLayout
+      title={guide.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Guides", href: "/ressources/guides" },
+        { label: guide.title },
+      ]}
+    >
+      <p>
+        Retrouvez la liste complète des guides sur la page <Link className="underline" href="/ressources/guides">Guides</Link>.
+      </p>
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Ressources associées"
+        links={[
+          { href: "/faq", label: "Consulter la FAQ" },
+          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
+        ]}
+      />
+      <p>
+        Retour aux <Link className="underline" href="/ressources/guides">Guides</Link> ou <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/guides/page.tsx
+++ b/app/ressources/guides/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { guides } from "@/lib/site-structure"
+
+export const metadata = createPageMetadata({
+  title: "Guides",
+  path: "/ressources/guides",
+  description: "Contenu à venir.",
+})
+
+export default function GuidesPage() {
+  return (
+    <SimplePageLayout
+      title="Guides"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Guides" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {guides.map((guide) => (
+          <Link
+            key={guide.slug}
+            href={`/ressources/guides/${guide.slug}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {guide.title}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/outils/[slug]/page.tsx
+++ b/app/ressources/outils/[slug]/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import { outils, outilsMap } from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return outils.map((item) => ({ slug: item.slug }))
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  const outil = outilsMap.get(params.slug)
+  if (!outil) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: outil.title,
+    path: `/ressources/outils/${outil.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function OutilPage({ params }: { params: { slug: string } }) {
+  const outil = outilsMap.get(params.slug)
+
+  if (!outil) {
+    notFound()
+  }
+
+  return (
+    <SimplePageLayout
+      title={outil.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Outils", href: "/ressources/outils" },
+        { label: outil.title },
+      ]}
+    >
+      <p>
+        Retour à la liste des <Link className="underline" href="/ressources/outils">Outils</Link>.
+      </p>
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Ressources associées"
+        links={[
+          { href: "/services", label: "Voir les services" },
+          { href: "/faq", label: "Consulter la FAQ" },
+        ]}
+      />
+      <p>
+        Fin de la fiche outil. Retour aux <Link className="underline" href="/ressources/outils">Outils</Link> ou <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/outils/page.tsx
+++ b/app/ressources/outils/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { outils } from "@/lib/site-structure"
+
+export const metadata = createPageMetadata({
+  title: "Outils",
+  path: "/ressources/outils",
+  description: "Contenu à venir.",
+})
+
+export default function OutilsPage() {
+  return (
+    <SimplePageLayout
+      title="Outils"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Outils" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {outils.map((outil) => (
+          <Link
+            key={outil.slug}
+            href={`/ressources/outils/${outil.slug}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {outil.title}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/page.tsx
+++ b/app/ressources/page.tsx
@@ -1,0 +1,46 @@
+import Link from "next/link"
+import { createPageMetadata } from "@/lib/metadata"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+
+const sections = [
+  { href: "/blog", label: "Blog" },
+  { href: "/ressources/guides", label: "Guides" },
+  { href: "/ressources/question-hub-ia", label: "Question-Hub IA" },
+  { href: "/ressources/comparatifs", label: "Comparatifs" },
+  { href: "/ressources/glossaire", label: "Glossaire" },
+  { href: "/ressources/outils", label: "Outils" },
+  { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
+]
+
+export const metadata = createPageMetadata({
+  title: "Ressources",
+  path: "/ressources",
+  description: "Contenu à venir.",
+})
+
+export default function RessourcesPage() {
+  return (
+    <SimplePageLayout
+      title="Ressources"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {sections.map((section) => (
+          <Link
+            key={section.href}
+            href={section.href}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {section.label}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/qh/[category]/[slug]/page.tsx
+++ b/app/ressources/qh/[category]/[slug]/page.tsx
@@ -1,0 +1,67 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import { questionHubEntries } from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return questionHubEntries.map((entry) => ({ category: entry.category, slug: entry.slug }))
+}
+
+export function generateMetadata({ params }: { params: { category: string; slug: string } }) {
+  const entry = questionHubEntries.find((item) => item.category === params.category && item.slug === params.slug)
+
+  if (!entry) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: entry.title,
+    path: `/ressources/qh/${entry.category}/${entry.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function QuestionHubEntryPage({ params }: { params: { category: string; slug: string } }) {
+  const entry = questionHubEntries.find((item) => item.category === params.category && item.slug === params.slug)
+
+  if (!entry) {
+    notFound()
+  }
+
+  const categoryLabel = entry.category.replace(/-/g, " ")
+  const categoryHref = `/ressources/qh/${entry.category}`
+
+  return (
+    <SimplePageLayout
+      title={entry.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Question-Hub IA", href: "/ressources/question-hub-ia" },
+        { label: categoryLabel, href: categoryHref },
+        { label: entry.title },
+      ]}
+    >
+      <p>
+        Retour aux questions : <Link className="underline" href={categoryHref}>{categoryLabel}</Link>.
+      </p>
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Pour aller plus loin"
+        links={[
+          { href: "/faq", label: "Consulter la FAQ" },
+          { href: "/ressources/guides", label: "Voir les guides" },
+        ]}
+      />
+      <p>
+        Fin de l'article. Retour à la page <Link className="underline" href={categoryHref}>{categoryLabel}</Link> ou <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/qh/[category]/page.tsx
+++ b/app/ressources/qh/[category]/page.tsx
@@ -1,0 +1,62 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { questionHubEntries } from "@/lib/site-structure"
+
+const categories = Array.from(new Set(questionHubEntries.map((entry) => entry.category)))
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return categories.map((category) => ({ category }))
+}
+
+export function generateMetadata({ params }: { params: { category: string } }) {
+  if (!categories.includes(params.category)) {
+    return {}
+  }
+
+  const title = `Question-Hub IA - ${params.category.replace(/-/g, " ")}`
+
+  return createPageMetadata({
+    title,
+    path: `/ressources/qh/${params.category}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function QuestionHubCategoryPage({ params }: { params: { category: string } }) {
+  if (!categories.includes(params.category)) {
+    notFound()
+  }
+
+  const items = questionHubEntries.filter((entry) => entry.category === params.category)
+
+  return (
+    <SimplePageLayout
+      title={`Question-Hub IA - ${params.category.replace(/-/g, " ")}`}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Question-Hub IA", href: "/ressources/question-hub-ia" },
+        { label: params.category.replace(/-/g, " ") },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {items.map((item) => (
+          <Link
+            key={item.slug}
+            href={`/ressources/qh/${item.category}/${item.slug}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {item.title}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/ressources/question-hub-ia/page.tsx
+++ b/app/ressources/question-hub-ia/page.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { questionHubEntries } from "@/lib/site-structure"
+
+const categories = Array.from(
+  questionHubEntries.reduce((acc, entry) => {
+    acc.add(entry.category)
+    return acc
+  }, new Set<string>())
+)
+
+export const metadata = createPageMetadata({
+  title: "Question-Hub IA",
+  path: "/ressources/question-hub-ia",
+  description: "Contenu à venir.",
+})
+
+export default function QuestionHubPage() {
+  return (
+    <SimplePageLayout
+      title="Question-Hub IA"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Ressources", href: "/ressources" },
+        { label: "Question-Hub IA" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {categories.map((category) => (
+          <Link
+            key={category}
+            href={`/ressources/qh/${category}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30 capitalize"
+          >
+            {category.replace(/-/g, " ")}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/rgpd/page.tsx
+++ b/app/rgpd/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Politique de confidentialité",
+  path: "/rgpd",
+  description: "Contenu à venir.",
+})
+
+export default function RgpdPage() {
+  return (
+    <SimplePageLayout
+      title="Politique de confidentialité"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Politique de confidentialité" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Consultez aussi notre <Link className="underline" href="/cookies">politique cookies</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from "next/server"
+import { BASE_URL } from "@/lib/site-structure"
+
+export function GET() {
+  const body = `User-agent: *\nAllow: /\nSitemap: ${new URL("/sitemap.xml", BASE_URL).toString()}\nDisallow: /api`
+
+  return new NextResponse(body, {
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  })
+}
+

--- a/app/secteurs/[slug]/[topic]/page.tsx
+++ b/app/secteurs/[slug]/[topic]/page.tsx
@@ -1,0 +1,88 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import {
+  sectorSubpages,
+  sectorSubpagesMap,
+  sectors,
+  sectorsMap,
+  servicesMap,
+} from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  const params: { slug: string; topic: string }[] = []
+  sectors.forEach((sector) => {
+    sectorSubpages.forEach((sub) => {
+      params.push({ slug: sector.slug, topic: sub.slug })
+    })
+  })
+  return params
+}
+
+export function generateMetadata({ params }: { params: { slug: string; topic: string } }) {
+  const sector = sectorsMap.get(params.slug)
+  const topic = sectorSubpagesMap.get(params.topic)
+
+  if (!sector || !topic) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: `${topic.title} - ${sector.title}`,
+    path: `/secteurs/${sector.slug}/${topic.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function SectorSubPage({ params }: { params: { slug: string; topic: string } }) {
+  const sector = sectorsMap.get(params.slug)
+  const topic = sectorSubpagesMap.get(params.topic)
+
+  if (!sector || !topic) {
+    notFound()
+  }
+
+  const serviceLinks = sector.relatedServices
+    .map((slug) => {
+      const item = servicesMap.get(slug)
+      return item ? { href: `/services/${slug}`, label: item.title } : null
+    })
+    .filter(Boolean) as { href: string; label: string }[]
+
+  const extendedLinks = [
+    ...serviceLinks,
+    { href: "/services/audit-diagnostic", label: "Audit et diagnostic automation" },
+  ]
+
+  return (
+    <SimplePageLayout
+      title={topic.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Secteurs", href: "/secteurs" },
+        { label: sector.title, href: `/secteurs/${sector.slug}` },
+        { label: topic.title },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection title="Retour au secteur" links={[{ href: `/secteurs/${sector.slug}`, label: sector.title }]} />
+      <LinkSection title="Services recommandés" links={extendedLinks} />
+      <LinkSection
+        title="Ressources"
+        links={[
+          { href: "/faq", label: "Consulter la FAQ" },
+          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
+        ]}
+      />
+      <p>
+        Besoin d'aide ? <Link className="underline" href="/contact">Contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/secteurs/[slug]/page.tsx
+++ b/app/secteurs/[slug]/page.tsx
@@ -1,0 +1,91 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import {
+  casUsageMap,
+  sectorSubpages,
+  sectors,
+  sectorsMap,
+  servicesMap,
+} from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return sectors.map((sector) => ({ slug: sector.slug }))
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  const sector = sectorsMap.get(params.slug)
+  if (!sector) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: sector.title,
+    path: `/secteurs/${sector.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function SectorPage({ params }: { params: { slug: string } }) {
+  const sector = sectorsMap.get(params.slug)
+
+  if (!sector) {
+    notFound()
+  }
+
+  const casLinks = sector.relatedCasUsage
+    .map((slug) => {
+      const item = casUsageMap.get(slug)
+      return item ? { href: `/cas-usage/${slug}`, label: item.title } : null
+    })
+    .filter(Boolean) as { href: string; label: string }[]
+
+  const serviceLinks = sector.relatedServices
+    .map((slug) => {
+      const item = servicesMap.get(slug)
+      return item ? { href: `/services/${slug}`, label: item.title } : null
+    })
+    .filter(Boolean) as { href: string; label: string }[]
+
+  const subpageLinks = sectorSubpages.map((sub) => ({
+    href: `/secteurs/${sector.slug}/${sub.slug}`,
+    label: sub.title,
+  }))
+
+  const extendedServiceLinks = [
+    ...serviceLinks,
+    { href: "/services/audit-diagnostic", label: "Audit et diagnostic automation" },
+  ]
+
+  return (
+    <SimplePageLayout
+      title={sector.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Secteurs", href: "/secteurs" },
+        { label: sector.title },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection title="Cas d'usage associés" links={casLinks} />
+      <LinkSection title="Services recommandés" links={extendedServiceLinks} />
+      <LinkSection title="Pages du secteur" links={subpageLinks} />
+      <LinkSection
+        title="Ressources"
+        links={[
+          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
+          { href: "/faq", label: "Consulter la FAQ" },
+        ]}
+      />
+      <p>
+        Pour plus d'informations, <Link className="underline" href="/contact">contactez-nous</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/secteurs/page.tsx
+++ b/app/secteurs/page.tsx
@@ -1,0 +1,38 @@
+import Link from "next/link"
+import { createPageMetadata } from "@/lib/metadata"
+import { sectors, sectorSubpages } from "@/lib/site-structure"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+
+export const metadata = createPageMetadata({
+  title: "Secteurs",
+  path: "/secteurs",
+  description: "Contenu à venir.",
+})
+
+export default function SectorsPage() {
+  return (
+    <SimplePageLayout
+      title="Secteurs"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Secteurs" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {sectors.map((sector) => (
+          <Link
+            key={sector.slug}
+            href={`/secteurs/${sector.slug}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {sector.title}
+          </Link>
+        ))}
+      </div>
+      <p className="text-sm text-white/60">Chaque secteur dispose de {sectorSubpages.length} sous-pages.</p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/services/[slug]/page.tsx
+++ b/app/services/[slug]/page.tsx
@@ -1,0 +1,83 @@
+import Link from "next/link"
+import { notFound } from "next/navigation"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+import {
+  casUsageMap,
+  sectorsMap,
+  services,
+  servicesMap,
+} from "@/lib/site-structure"
+
+export const dynamicParams = false
+
+export function generateStaticParams() {
+  return services.map((service) => ({ slug: service.slug }))
+}
+
+export function generateMetadata({ params }: { params: { slug: string } }) {
+  const service = servicesMap.get(params.slug)
+  if (!service) {
+    return {}
+  }
+
+  return createPageMetadata({
+    title: service.title,
+    path: `/services/${service.slug}`,
+    description: "Contenu à venir.",
+  })
+}
+
+export default function ServicePage({ params }: { params: { slug: string } }) {
+  const service = servicesMap.get(params.slug)
+
+  if (!service) {
+    notFound()
+  }
+
+  const casLinks = service.relatedCasUsage
+    .map((slug) => {
+      const item = casUsageMap.get(slug)
+      return item ? { href: `/cas-usage/${slug}`, label: item.title } : null
+    })
+    .filter(Boolean) as { href: string; label: string }[]
+
+  const sectorLinks = service.relatedSectors
+    .map((slug) => {
+      const item = sectorsMap.get(slug)
+      return item ? { href: `/secteurs/${slug}`, label: item.title } : null
+    })
+    .filter(Boolean) as { href: string; label: string }[]
+
+  return (
+    <SimplePageLayout
+      title={service.title}
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Services", href: "/services" },
+        { label: service.title },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Informations clés"
+        links={[
+          { href: "/methode", label: "Découvrir la méthode" },
+          { href: "/tarifs", label: "Consulter les tarifs" },
+          { href: "/faq", label: "Voir la FAQ" },
+        ]}
+      />
+      <LinkSection title="Cas d'usage associés" links={casLinks} />
+      <LinkSection title="Secteurs concernés" links={sectorLinks} />
+      <section className="space-y-2">
+        <h2 className="text-xl font-semibold text-white">Contact</h2>
+        <p>
+          Besoin d'échanger ? <Link className="underline" href="/contact">Contactez-nous</Link>.
+        </p>
+      </section>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link"
+import { createPageMetadata } from "@/lib/metadata"
+import { services } from "@/lib/site-structure"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+
+export const metadata = createPageMetadata({
+  title: "Services",
+  path: "/services",
+  description: "Contenu à venir.",
+})
+
+export default function ServicesPage() {
+  return (
+    <SimplePageLayout
+      title="Services"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Services" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {services.map((service) => (
+          <Link
+            key={service.slug}
+            href={`/services/${service.slug}`}
+            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
+          >
+            {service.title}
+          </Link>
+        ))}
+      </div>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from "next/server"
+import { BASE_URL, getAllRoutes } from "@/lib/site-structure"
+
+export function GET() {
+  const urls = getAllRoutes()
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls
+    .map((route) => `\n  <url><loc>${new URL(route, BASE_URL).toString()}</loc></url>`)
+    .join("")}\n</urlset>`
+
+  return new NextResponse(body, {
+    headers: {
+      "Content-Type": "application/xml",
+    },
+  })
+}
+

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -1,0 +1,37 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { getAllRoutes } from "@/lib/site-structure"
+
+const routes = getAllRoutes().sort((a, b) => a.localeCompare(b))
+
+export const metadata = createPageMetadata({
+  title: "Plan du site",
+  path: "/sitemap",
+  description: "Contenu à venir.",
+})
+
+export default function SitemapPage() {
+  return (
+    <SimplePageLayout
+      title="Plan du site"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Plan du site" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <ul className="grid gap-2 sm:grid-cols-2">
+        {routes.map((route) => (
+          <li key={route}>
+            <Link className="underline" href={route}>
+              {route}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/status/page.tsx
+++ b/app/status/page.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Status",
+  path: "/status",
+  description: "Contenu à venir.",
+})
+
+export default function StatusPage() {
+  return (
+    <SimplePageLayout
+      title="Status"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Status" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <p>
+        Retrouvez aussi le <Link className="underline" href="/changelog">changelog</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/app/tarifs/page.tsx
+++ b/app/tarifs/page.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { LinkSection } from "@/components/link-section"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Tarifs",
+  path: "/tarifs",
+  description: "Contenu à venir.",
+})
+
+export default function TarifsPage() {
+  return (
+    <SimplePageLayout
+      title="Tarifs"
+      description="Contenu à venir."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Tarifs" },
+      ]}
+    >
+      <p>Contenu à venir.</p>
+      <LinkSection
+        title="Outils utiles"
+        links={[
+          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
+          { href: "/contact", label: "Obtenir une estimation" },
+        ]}
+      />
+      <p>
+        Explorez aussi nos <Link className="underline" href="/services">services</Link>.
+      </p>
+    </SimplePageLayout>
+  )
+}
+

--- a/components/breadcrumbs.tsx
+++ b/components/breadcrumbs.tsx
@@ -1,0 +1,35 @@
+import Link from "next/link"
+
+export type BreadcrumbItem = {
+  label: string
+  href?: string
+}
+
+export const Breadcrumbs = ({ items }: { items: BreadcrumbItem[] }) => {
+  if (!items.length) {
+    return null
+  }
+
+  return (
+    <nav aria-label="Fil d'Ariane" className="text-sm text-white/70">
+      <ol className="flex flex-wrap items-center gap-1">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1
+          return (
+            <li key={`${item.label}-${index}`} className="flex items-center gap-1">
+              {item.href && !isLast ? (
+                <Link className="hover:text-white transition-colors" href={item.href}>
+                  {item.label}
+                </Link>
+              ) : (
+                <span className={isLast ? "text-white" : undefined}>{item.label}</span>
+              )}
+              {!isLast && <span className="text-white/40">/</span>}
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}
+

--- a/components/cookie-banner.tsx
+++ b/components/cookie-banner.tsx
@@ -1,0 +1,51 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import Link from "next/link"
+
+const STORAGE_KEY = "cookie-consent"
+
+export const CookieBanner = () => {
+  const [visible, setVisible] = useState(false)
+
+  useEffect(() => {
+    const stored = typeof window !== "undefined" ? window.localStorage.getItem(STORAGE_KEY) : null
+    setVisible(!stored)
+  }, [])
+
+  const handleConsent = (value: "accepted" | "rejected") => {
+    window.localStorage.setItem(STORAGE_KEY, value)
+    setVisible(false)
+  }
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <div className="fixed bottom-4 inset-x-0 px-4 z-[9999]">
+      <div className="max-w-4xl mx-auto bg-white/10 backdrop-blur-xl border border-white/20 rounded-2xl p-6 text-white shadow-lg">
+        <h2 className="text-lg font-semibold mb-2">Cookies</h2>
+        <p className="text-sm text-white/80">
+          Nous utilisons des cookies nécessitant votre consentement pour les mesures d'audience et le marketing. Vous pouvez en
+          savoir plus dans notre <Link className="underline" href="/cookies">politique cookies</Link>.
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <button
+            onClick={() => handleConsent("accepted")}
+            className="px-4 py-2 rounded-full bg-white text-black font-semibold hover:bg-white/80 transition"
+          >
+            Accepter
+          </button>
+          <button
+            onClick={() => handleConsent("rejected")}
+            className="px-4 py-2 rounded-full border border-white/40 hover:border-white/70 transition"
+          >
+            Refuser
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,127 +1,37 @@
 "use client"
 
 import Link from "next/link"
+import { footerLinks } from "@/lib/navigation"
 import { useParticles } from "./particle-context"
 
 export function Footer() {
   const { setHovering } = useParticles()
 
   return (
-    <footer className="bg-background border-t border-border relative z-10">
-      <div className="container mx-auto px-4 py-12">
-        <div className="grid md:grid-cols-4 gap-8">
-          <div>
-            <h3 className="font-sentient text-xl mb-4">AI Agency</h3>
-            <p className="text-muted-foreground text-sm leading-relaxed">
-              Transformons l'avenir avec l'intelligence artificielle. Solutions innovantes pour entreprises
-              visionnaires.
-            </p>
-          </div>
-
-          <div>
-            <h4 className="font-semibold mb-4">Services</h4>
-            <ul className="space-y-2 text-sm">
-              <li>
-                <Link
-                  href="#"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onMouseEnter={() => setHovering(true)}
-                  onMouseLeave={() => setHovering(false)}
-                >
-                  IA Générative
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="#"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onMouseEnter={() => setHovering(true)}
-                  onMouseLeave={() => setHovering(false)}
-                >
-                  Automatisation
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="#"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onMouseEnter={() => setHovering(true)}
-                  onMouseLeave={() => setHovering(false)}
-                >
-                  Analyse Prédictive
-                </Link>
-              </li>
-            </ul>
-          </div>
-
-          <div>
-            <h4 className="font-semibold mb-4">Entreprise</h4>
-            <ul className="space-y-2 text-sm">
-              <li>
-                <Link
-                  href="#"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onMouseEnter={() => setHovering(true)}
-                  onMouseLeave={() => setHovering(false)}
-                >
-                  À propos
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="#"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onMouseEnter={() => setHovering(true)}
-                  onMouseLeave={() => setHovering(false)}
-                >
-                  Équipe
-                </Link>
-              </li>
-              <li>
-                <Link
-                  href="#"
-                  className="text-muted-foreground hover:text-foreground transition-colors"
-                  onMouseEnter={() => setHovering(true)}
-                  onMouseLeave={() => setHovering(false)}
-                >
-                  Carrières
-                </Link>
-              </li>
-            </ul>
-          </div>
-
-          <div>
-            <h4 className="font-semibold mb-4">Contact</h4>
-            <ul className="space-y-2 text-sm text-muted-foreground">
-              <li>contact@aiagency.com</li>
-              <li>+33 1 23 45 67 89</li>
-              <li>Paris, France</li>
-            </ul>
-          </div>
+    <footer className="bg-black/90 border-t border-white/10 relative z-10 text-white">
+      <div className="max-w-5xl mx-auto px-6 py-12 space-y-8">
+        <div>
+          <h3 className="text-2xl font-semibold">Skal Ventures</h3>
+          <p className="text-white/60 text-sm">Contenu à venir.</p>
         </div>
 
-        <div className="border-t border-border mt-12 pt-8 flex flex-col md:flex-row justify-between items-center">
-          <p className="text-sm text-muted-foreground">© 2025 AI Agency. Tous droits réservés.</p>
-          <div className="flex space-x-6 mt-4 md:mt-0">
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 text-sm">
+          {footerLinks.map((item) => (
             <Link
-              href="#"
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+              key={item.href}
+              href={item.href}
               onMouseEnter={() => setHovering(true)}
               onMouseLeave={() => setHovering(false)}
+              className="text-white/70 hover:text-white transition"
             >
-              Politique de confidentialité
+              {item.label}
             </Link>
-            <Link
-              href="#"
-              className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-              onMouseEnter={() => setHovering(true)}
-              onMouseLeave={() => setHovering(false)}
-            >
-              Mentions légales
-            </Link>
-          </div>
+          ))}
         </div>
+
+        <div className="border-t border-white/10 pt-6 text-xs text-white/60">© {new Date().getFullYear()} Skal Ventures.</div>
       </div>
     </footer>
   )
 }
+

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,6 +2,7 @@ import Link from "next/link"
 import { Logo } from "./logo"
 import { MobileMenu } from "./mobile-menu"
 import { InteractiveLink } from "./interactive-link"
+import { primaryNav } from "@/lib/navigation"
 
 export const Header = () => {
   return (
@@ -13,25 +14,36 @@ export const Header = () => {
             <Logo className="w-[240px] sm:w-[280px]" />
           </Link>
 
-          <nav className="hidden lg:flex items-center gap-8">
-            {[
-              { name: "Services", href: "#services" },
-              { name: "Expertise", href: "#expertise" },
-              { name: "Projets", href: "#projects" },
-              { name: "Contact", href: "#contact" },
-            ].map((item) => (
-              <InteractiveLink
-                className="text-lg font-bold text-white/80 hover:text-white transition-colors duration-200 relative after:absolute after:bottom-0 after:left-0 after:w-0 after:h-px after:bg-white after:transition-all after:duration-300 hover:after:w-full"
-                href={item.href}
-                key={item.name}
-              >
-                {item.name}
-              </InteractiveLink>
+          <nav className="hidden lg:flex items-center gap-6">
+            {primaryNav.map((item) => (
+              <div key={item.label} className="relative group">
+                <InteractiveLink
+                  className="text-lg font-bold text-white/80 hover:text-white transition-colors duration-200"
+                  href={item.href}
+                >
+                  {item.label}
+                </InteractiveLink>
+                {item.children && (
+                  <div className="absolute left-0 mt-4 hidden w-max min-w-[240px] rounded-2xl border border-white/10 bg-black/90 p-4 shadow-2xl group-hover:block group-focus-within:block">
+                    <div className="grid max-h-[420px] gap-2 overflow-y-auto pr-2">
+                      {item.children.map((child) => (
+                        <Link
+                          key={child.href}
+                          href={child.href}
+                          className="text-sm text-white/80 hover:text-white transition"
+                        >
+                          {child.label}
+                        </Link>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </div>
             ))}
           </nav>
 
           <div className="lg:hidden">
-            <MobileMenu />
+            <MobileMenu navItems={primaryNav} />
           </div>
         </header>
       </div>

--- a/components/home-links.tsx
+++ b/components/home-links.tsx
@@ -1,0 +1,123 @@
+import Link from "next/link"
+import {
+  guides,
+  homeRequiredLinks,
+  servicesMap,
+  casUsageMap,
+  sectorsMap,
+} from "@/lib/site-structure"
+
+const featuredGuides = guides.slice(0, 3)
+
+export const HomeLinks = () => {
+  return (
+    <section className="bg-black/60 border-t border-white/10 py-16">
+      <div className="max-w-5xl mx-auto px-6 space-y-8 text-white">
+        <div>
+          <h2 className="text-3xl font-semibold">Parcours rapides</h2>
+          <p className="text-white/70">Contenu à venir.</p>
+        </div>
+        <div className="grid gap-8 md:grid-cols-2">
+          <div className="space-y-4">
+            <h3 className="text-xl font-semibold">Services clés</h3>
+            <ul className="space-y-2 text-white/80">
+              {homeRequiredLinks.services.map((href) => {
+                const slug = href.split("/").pop() ?? ""
+                const label = servicesMap.get(slug)?.title ?? href
+                return (
+                  <li key={href}>
+                    <Link className="underline" href={href}>
+                      {label}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+          <div className="space-y-4">
+            <h3 className="text-xl font-semibold">Cas d'usage</h3>
+            <ul className="space-y-2 text-white/80">
+              {homeRequiredLinks.casUsage.map((href) => {
+                const slug = href.split("/").pop() ?? ""
+                const label = casUsageMap.get(slug)?.title ?? href
+                return (
+                  <li key={href}>
+                    <Link className="underline" href={href}>
+                      {label}
+                    </Link>
+                  </li>
+                )
+              })}
+            </ul>
+          </div>
+        </div>
+        <div className="space-y-4">
+          <h3 className="text-xl font-semibold">Secteurs</h3>
+          <ul className="space-y-2 text-white/80">
+            {homeRequiredLinks.sectors.map((href) => {
+              const slug = href.split("/").pop() ?? ""
+              const label = sectorsMap.get(slug)?.title ?? href
+              return (
+                <li key={href}>
+                  <Link className="underline" href={href}>
+                    {label}
+                  </Link>
+                </li>
+              )
+            })}
+            <li>
+              <Link className="underline" href="/secteurs">
+                Tous les secteurs
+              </Link>
+            </li>
+          </ul>
+        </div>
+        <div className="grid gap-8 md:grid-cols-2">
+          <div className="space-y-4">
+            <h3 className="text-xl font-semibold">Guides à consulter</h3>
+            <ul className="space-y-2 text-white/80">
+              {featuredGuides.map((guide) => (
+                <li key={guide.slug}>
+                  <Link className="underline" href={`/ressources/guides/${guide.slug}`}>
+                    {guide.title}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="space-y-4">
+            <h3 className="text-xl font-semibold">Raccourcis</h3>
+            <ul className="space-y-2 text-white/80">
+              <li>
+                <Link className="underline" href="/methode">
+                  /methode
+                </Link>
+              </li>
+              <li>
+                <Link className="underline" href="/tarifs">
+                  /tarifs
+                </Link>
+              </li>
+              <li>
+                <Link className="underline" href="/ressources/calculateur-roi">
+                  /ressources/calculateur-roi
+                </Link>
+              </li>
+              <li>
+                <Link className="underline" href="/ressources/question-hub-ia">
+                  /ressources/question-hub-ia
+                </Link>
+              </li>
+              <li>
+                <Link className="underline" href="/contact">
+                  /contact
+                </Link>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+

--- a/components/link-section.tsx
+++ b/components/link-section.tsx
@@ -1,0 +1,28 @@
+import Link from "next/link"
+
+export type LinkItem = {
+  href: string
+  label: string
+}
+
+export const LinkSection = ({ title, links }: { title: string; links: LinkItem[] }) => {
+  if (!links.length) {
+    return null
+  }
+
+  return (
+    <section className="space-y-3">
+      <h2 className="text-xl font-semibold text-white">{title}</h2>
+      <ul className="list-disc space-y-1 pl-6 text-white/80">
+        {links.map((link) => (
+          <li key={`${title}-${link.href}`}>
+            <Link className="hover:text-white transition" href={link.href}>
+              {link.label}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+

--- a/components/mobile-menu.tsx
+++ b/components/mobile-menu.tsx
@@ -5,20 +5,15 @@ import * as Dialog from "@radix-ui/react-dialog"
 import { Menu, X } from "lucide-react"
 import { useState } from "react"
 import { InteractiveLink } from "./interactive-link"
+import type { NavItem } from "@/lib/navigation"
 
 interface MobileMenuProps {
   className?: string
+  navItems: NavItem[]
 }
 
-export const MobileMenu = ({ className }: MobileMenuProps) => {
+export const MobileMenu = ({ className, navItems }: MobileMenuProps) => {
   const [isOpen, setIsOpen] = useState(false)
-
-  const menuItems = [
-    { name: "About", href: "#about" },
-    { name: "Portfolio", href: "#portfolio" },
-    { name: "Insights", href: "#insights" },
-    { name: "Contact", href: "#contact" },
-  ]
 
   const handleLinkClick = () => {
     setIsOpen(false)
@@ -27,10 +22,7 @@ export const MobileMenu = ({ className }: MobileMenuProps) => {
   return (
     <Dialog.Root modal={false} open={isOpen} onOpenChange={setIsOpen}>
       <Dialog.Trigger asChild>
-        <button
-          className={cn("group lg:hidden p-2 text-foreground transition-colors", className)}
-          aria-label="Open menu"
-        >
+        <button className={cn("group lg:hidden p-2 text-foreground transition-colors", className)} aria-label="Open menu">
           <Menu className="group-[[data-state=open]]:hidden" size={24} />
           <X className="hidden group-[[data-state=open]]:block" size={24} />
         </button>
@@ -50,29 +42,35 @@ export const MobileMenu = ({ className }: MobileMenuProps) => {
           <Dialog.Title className="sr-only">Menu</Dialog.Title>
 
           <nav className="flex flex-col space-y-6 container mx-auto">
-            {menuItems.map((item) => (
-              <InteractiveLink
-                key={item.name}
-                href={item.href}
-                onClick={handleLinkClick}
-                className="text-xl font-mono uppercase text-foreground/60 transition-colors ease-out duration-150 hover:text-foreground/100 py-2"
-              >
-                {item.name}
-              </InteractiveLink>
+            {navItems.map((item) => (
+              <div key={item.label} className="space-y-2">
+                <InteractiveLink
+                  href={item.href}
+                  onClick={handleLinkClick}
+                  className="text-xl font-mono uppercase text-foreground/60 transition-colors ease-out duration-150 hover:text-foreground/100 py-2"
+                >
+                  {item.label}
+                </InteractiveLink>
+                {item.children && (
+                  <div className="pl-4 space-y-2">
+                    {item.children.map((child) => (
+                      <InteractiveLink
+                        key={child.href}
+                        href={child.href}
+                        onClick={handleLinkClick}
+                        className="block text-base text-foreground/60 transition-colors hover:text-foreground/100"
+                      >
+                        {child.label}
+                      </InteractiveLink>
+                    ))}
+                  </div>
+                )}
+              </div>
             ))}
-
-            <div className="mt-6">
-              <InteractiveLink
-                href="/#sign-in"
-                onClick={handleLinkClick}
-                className="inline-block text-xl font-mono uppercase text-primary transition-colors ease-out duration-150 hover:text-primary/80 py-2"
-              >
-                Sign In
-              </InteractiveLink>
-            </div>
           </nav>
         </Dialog.Content>
       </Dialog.Portal>
     </Dialog.Root>
   )
 }
+

--- a/components/simple-page-layout.tsx
+++ b/components/simple-page-layout.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react"
+import { Header } from "./header"
+import { Footer } from "./footer"
+import { Breadcrumbs, type BreadcrumbItem } from "./breadcrumbs"
+
+type SimplePageLayoutProps = {
+  title: string
+  description?: ReactNode
+  breadcrumbs?: BreadcrumbItem[]
+  children: ReactNode
+}
+
+export const SimplePageLayout = ({
+  title,
+  description,
+  breadcrumbs,
+  children,
+}: SimplePageLayoutProps) => {
+  return (
+    <div className="bg-black text-white min-h-screen">
+      <Header />
+      <main className="pt-36 pb-20">
+        <div className="max-w-5xl mx-auto px-6 space-y-8">
+          {breadcrumbs && <Breadcrumbs items={breadcrumbs} />}
+          <div className="space-y-4">
+            <h1 className="text-4xl font-bold">{title}</h1>
+            {description && <div className="text-white/80">{description}</div>}
+          </div>
+          <div className="space-y-6 text-white/90">{children}</div>
+        </div>
+      </main>
+      <Footer />
+    </div>
+  )
+}
+

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,0 +1,40 @@
+import type { Metadata } from "next"
+import { BASE_URL, indexablePaths } from "./site-structure"
+
+type MetadataParams = {
+  title: string
+  description?: string
+  path: string
+}
+
+export const createPageMetadata = ({ title, description, path }: MetadataParams): Metadata => {
+  const allowIndex = process.env.SEO_INDEX_ALL === "true" || indexablePaths.has(path)
+
+  const metaDescription = description ?? "Contenu à venir."
+  const canonical = new URL(path, BASE_URL).toString()
+
+  return {
+    title: `${title} | Skal Ventures`,
+    description: metaDescription,
+    alternates: {
+      canonical,
+      languages: {
+        "fr-FR": canonical,
+      },
+    },
+    openGraph: {
+      title: `${title} | Skal Ventures`,
+      description: metaDescription,
+      url: canonical,
+      locale: "fr_FR",
+      siteName: "Skal Ventures",
+    },
+    robots: allowIndex
+      ? undefined
+      : {
+          index: false,
+          follow: false,
+        },
+  }
+}
+

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,0 +1,67 @@
+import { casUsage, sectors, services } from "./site-structure"
+
+export type NavItem = {
+  label: string
+  href: string
+  children?: { label: string; href: string }[]
+}
+
+export const primaryNav: NavItem[] = [
+  { label: "Accueil", href: "/" },
+  { label: "Méthode", href: "/methode" },
+  {
+    label: "Services",
+    href: "/services",
+    children: services.map((service) => ({
+      label: service.title,
+      href: `/services/${service.slug}`,
+    })),
+  },
+  {
+    label: "Cas d'usage",
+    href: "/cas-usage",
+    children: casUsage.map((item) => ({
+      label: item.title,
+      href: `/cas-usage/${item.slug}`,
+    })),
+  },
+  {
+    label: "Secteurs",
+    href: "/secteurs",
+    children: sectors.map((item) => ({
+      label: item.title,
+      href: `/secteurs/${item.slug}`,
+    })),
+  },
+  {
+    label: "Ressources",
+    href: "/ressources",
+    children: [
+      { label: "Blog", href: "/blog" },
+      { label: "Guides", href: "/ressources/guides" },
+      { label: "Question-Hub IA", href: "/ressources/question-hub-ia" },
+      { label: "Comparatifs", href: "/ressources/comparatifs" },
+      { label: "Glossaire", href: "/ressources/glossaire" },
+      { label: "Outils", href: "/ressources/outils" },
+      { label: "Calculateur ROI", href: "/ressources/calculateur-roi" },
+    ],
+  },
+  { label: "Tarifs", href: "/tarifs" },
+  { label: "FAQ", href: "/faq" },
+  { label: "Contact", href: "/contact" },
+]
+
+export const footerLinks = [
+  { label: "Mentions légales", href: "/mentions-legales" },
+  { label: "Politique RGPD", href: "/rgpd" },
+  { label: "Cookies", href: "/cookies" },
+  { label: "DPA", href: "/dpa" },
+  { label: "Conditions générales", href: "/conditions-generales" },
+  { label: "Sitemap", href: "/sitemap" },
+  { label: "Status", href: "/status" },
+  { label: "Changelog", href: "/changelog" },
+  { label: "Contact", href: "/contact" },
+  { label: "Blog", href: "/blog" },
+  { label: "Tarifs", href: "/tarifs" },
+]
+

--- a/lib/site-structure.ts
+++ b/lib/site-structure.ts
@@ -1,0 +1,603 @@
+export const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL ?? "https://skal-ventures.example"
+
+export type RouteItem = {
+  slug: string
+  title: string
+  description?: string
+}
+
+export type ServiceItem = RouteItem & {
+  relatedCasUsage: string[]
+  relatedSectors: string[]
+}
+
+export type CasUsageItem = RouteItem & {
+  relatedServices: string[]
+  relatedSector: string
+}
+
+export type SectorItem = RouteItem & {
+  relatedCasUsage: string[]
+  relatedServices: string[]
+}
+
+export const services: ServiceItem[] = [
+  {
+    slug: "audit-diagnostic",
+    title: "Audit et diagnostic automation",
+    relatedCasUsage: ["commercial-marketing", "finance-comptabilite"],
+    relatedSectors: ["services-b2b", "industrie"],
+  },
+  {
+    slug: "automatisation-ia",
+    title: "Automatisation IA",
+    relatedCasUsage: ["dsi-it", "rh"],
+    relatedSectors: ["saas-editeurs", "telecom-medias"],
+  },
+  {
+    slug: "rpa",
+    title: "RPA",
+    relatedCasUsage: ["finance-comptabilite", "production-qualite"],
+    relatedSectors: ["banque-assurance", "industrie"],
+  },
+  {
+    slug: "llm-rag",
+    title: "LLM et RAG",
+    relatedCasUsage: ["service-client", "juridique"],
+    relatedSectors: ["sante", "collectivites-parapublic"],
+  },
+  {
+    slug: "agents-ia",
+    title: "Agents IA",
+    relatedCasUsage: ["service-client", "commercial-marketing"],
+    relatedSectors: ["retail-ecommerce", "saas-editeurs"],
+  },
+  {
+    slug: "integration-donnees-etl-n8n",
+    title: "Intégration de données ETL & n8n",
+    relatedCasUsage: ["dsi-it", "supply-chain-logistique"],
+    relatedSectors: ["transport-logistique", "energie-utilities"],
+  },
+  {
+    slug: "erp-crm-dev",
+    title: "ERP & CRM sur mesure",
+    relatedCasUsage: ["commercial-marketing", "pmo-gestion-de-projets"],
+    relatedSectors: ["agences-esn", "banque-assurance"],
+  },
+  {
+    slug: "odoo-integration",
+    title: "Intégration Odoo",
+    relatedCasUsage: ["finance-comptabilite", "achats-approvisionnements"],
+    relatedSectors: ["industrie", "retail-ecommerce"],
+  },
+  {
+    slug: "crm-automation",
+    title: "Automation CRM",
+    relatedCasUsage: ["commercial-marketing", "service-client"],
+    relatedSectors: ["saas-editeurs", "luxe-cosmetique"],
+  },
+  {
+    slug: "ecommerce-automation",
+    title: "Automation e-commerce",
+    relatedCasUsage: ["commercial-marketing", "supply-chain-logistique"],
+    relatedSectors: ["retail-ecommerce", "mode-textile"],
+  },
+  {
+    slug: "marketing-automation",
+    title: "Marketing automation",
+    relatedCasUsage: ["commercial-marketing", "service-client"],
+    relatedSectors: ["luxe-cosmetique", "tourisme-loisirs"],
+  },
+  {
+    slug: "sales-ops",
+    title: "Sales Ops",
+    relatedCasUsage: ["commercial-marketing", "pmo-gestion-de-projets"],
+    relatedSectors: ["services-b2b", "saas-editeurs"],
+  },
+  {
+    slug: "service-client-helpdesk",
+    title: "Service client & helpdesk",
+    relatedCasUsage: ["service-client", "maintenance"],
+    relatedSectors: ["telecom-medias", "sante"],
+  },
+  {
+    slug: "bi-analytics-reporting",
+    title: "BI, analytics & reporting",
+    relatedCasUsage: ["finance-comptabilite", "pmo-gestion-de-projets"],
+    relatedSectors: ["energie-utilities", "industrie"],
+  },
+  {
+    slug: "data-engineering",
+    title: "Data engineering",
+    relatedCasUsage: ["dsi-it", "production-qualite"],
+    relatedSectors: ["electronique", "energie-utilities"],
+  },
+  {
+    slug: "mlops",
+    title: "MLOps",
+    relatedCasUsage: ["dsi-it", "production-qualite"],
+    relatedSectors: ["pharma-medtech", "automobile-mobilite"],
+  },
+  {
+    slug: "gestion-documentaire-ged",
+    title: "Gestion documentaire GED",
+    relatedCasUsage: ["juridique", "rh"],
+    relatedSectors: ["collectivites-parapublic", "education"],
+  },
+  {
+    slug: "governance-rgpd-ai-act",
+    title: "Gouvernance RGPD & AI Act",
+    relatedCasUsage: ["juridique", "securite"],
+    relatedSectors: ["banque-assurance", "collectivites-parapublic"],
+  },
+  {
+    slug: "securite",
+    title: "Sécurité et conformité",
+    relatedCasUsage: ["securite", "dsi-it"],
+    relatedSectors: ["energie-utilities", "banque-assurance"],
+  },
+  {
+    slug: "support-maintenance",
+    title: "Support & maintenance",
+    relatedCasUsage: ["maintenance", "service-client"],
+    relatedSectors: ["automobile-mobilite", "industrie"],
+  },
+]
+
+export const casUsage: CasUsageItem[] = [
+  {
+    slug: "commercial-marketing",
+    title: "Cas d'usage Commercial & Marketing",
+    relatedServices: ["crm-automation", "marketing-automation"],
+    relatedSector: "retail-ecommerce",
+  },
+  {
+    slug: "service-client",
+    title: "Cas d'usage Service client",
+    relatedServices: ["service-client-helpdesk", "agents-ia"],
+    relatedSector: "telecom-medias",
+  },
+  {
+    slug: "finance-comptabilite",
+    title: "Cas d'usage Finance & Comptabilité",
+    relatedServices: ["rpa", "bi-analytics-reporting"],
+    relatedSector: "banque-assurance",
+  },
+  {
+    slug: "achats-approvisionnements",
+    title: "Cas d'usage Achats & Approvisionnements",
+    relatedServices: ["integration-donnees-etl-n8n", "odoo-integration"],
+    relatedSector: "industrie",
+  },
+  {
+    slug: "supply-chain-logistique",
+    title: "Cas d'usage Supply chain & logistique",
+    relatedServices: ["ecommerce-automation", "integration-donnees-etl-n8n"],
+    relatedSector: "transport-logistique",
+  },
+  {
+    slug: "production-qualite",
+    title: "Cas d'usage Production & Qualité",
+    relatedServices: ["mlops", "data-engineering"],
+    relatedSector: "industrie",
+  },
+  {
+    slug: "maintenance",
+    title: "Cas d'usage Maintenance",
+    relatedServices: ["support-maintenance", "rpa"],
+    relatedSector: "automobile-mobilite",
+  },
+  {
+    slug: "rh",
+    title: "Cas d'usage Ressources humaines",
+    relatedServices: ["agents-ia", "gestion-documentaire-ged"],
+    relatedSector: "education",
+  },
+  {
+    slug: "juridique",
+    title: "Cas d'usage Juridique",
+    relatedServices: ["governance-rgpd-ai-act", "gestion-documentaire-ged"],
+    relatedSector: "collectivites-parapublic",
+  },
+  {
+    slug: "dsi-it",
+    title: "Cas d'usage DSI & IT",
+    relatedServices: ["automatisation-ia", "data-engineering"],
+    relatedSector: "saas-editeurs",
+  },
+  {
+    slug: "securite",
+    title: "Cas d'usage Sécurité",
+    relatedServices: ["securite", "governance-rgpd-ai-act"],
+    relatedSector: "energie-utilities",
+  },
+  {
+    slug: "pmo-gestion-de-projets",
+    title: "Cas d'usage PMO & Gestion de projets",
+    relatedServices: ["erp-crm-dev", "bi-analytics-reporting"],
+    relatedSector: "services-b2b",
+  },
+]
+
+export const casUsageTasks: RouteItem[] = [
+  { slug: "prospection-multicanale-rgpd", title: "Prospection multicanale RGPD" },
+  { slug: "qualification-mql-sql", title: "Qualification MQL à SQL" },
+  { slug: "relances-automatiques", title: "Relances automatiques" },
+  { slug: "onboarding-clients", title: "Onboarding clients" },
+  { slug: "facturation-et-recouvrement", title: "Facturation et recouvrement" },
+  { slug: "cloture-mensuelle-rapide", title: "Clôture mensuelle rapide" },
+  { slug: "gestion-stocks", title: "Gestion des stocks" },
+  { slug: "ordonnancement", title: "Ordonnancement" },
+  { slug: "planification-tournees", title: "Planification des tournées" },
+  { slug: "controle-qualite", title: "Contrôle qualité" },
+  { slug: "maintenance-predictive", title: "Maintenance prédictive" },
+  { slug: "onboarding-salaries", title: "Onboarding salariés" },
+  { slug: "gestion-contrats", title: "Gestion des contrats" },
+  { slug: "conformite-rgpd-ai-act", title: "Conformité RGPD et AI Act" },
+  { slug: "ged-et-rag-documentaire", title: "GED et RAG documentaire" },
+  { slug: "tableaux-de-bord-kpi", title: "Tableaux de bord KPI" },
+]
+
+export const sectors: SectorItem[] = [
+  {
+    slug: "industrie",
+    title: "Secteur Industrie",
+    relatedCasUsage: ["production-qualite", "maintenance"],
+    relatedServices: ["rpa", "data-engineering"],
+  },
+  {
+    slug: "agroalimentaire",
+    title: "Secteur Agroalimentaire",
+    relatedCasUsage: ["supply-chain-logistique", "production-qualite"],
+    relatedServices: ["ecommerce-automation", "mlops"],
+  },
+  {
+    slug: "pharma-medtech",
+    title: "Secteur Pharma & Medtech",
+    relatedCasUsage: ["production-qualite", "securite"],
+    relatedServices: ["mlops", "governance-rgpd-ai-act"],
+  },
+  {
+    slug: "sante",
+    title: "Secteur Santé",
+    relatedCasUsage: ["service-client", "juridique"],
+    relatedServices: ["llm-rag", "service-client-helpdesk"],
+  },
+  {
+    slug: "energie-utilities",
+    title: "Secteur Énergie & Utilities",
+    relatedCasUsage: ["securite", "dsi-it"],
+    relatedServices: ["securite", "data-engineering"],
+  },
+  {
+    slug: "transport-logistique",
+    title: "Secteur Transport & Logistique",
+    relatedCasUsage: ["supply-chain-logistique", "maintenance"],
+    relatedServices: ["integration-donnees-etl-n8n", "support-maintenance"],
+  },
+  {
+    slug: "automobile-mobilite",
+    title: "Secteur Automobile & Mobilité",
+    relatedCasUsage: ["maintenance", "production-qualite"],
+    relatedServices: ["support-maintenance", "mlops"],
+  },
+  {
+    slug: "construction-btp",
+    title: "Secteur Construction & BTP",
+    relatedCasUsage: ["pmo-gestion-de-projets", "maintenance"],
+    relatedServices: ["erp-crm-dev", "support-maintenance"],
+  },
+  {
+    slug: "immobilier",
+    title: "Secteur Immobilier",
+    relatedCasUsage: ["commercial-marketing", "juridique"],
+    relatedServices: ["crm-automation", "governance-rgpd-ai-act"],
+  },
+  {
+    slug: "recyclage-dechets",
+    title: "Secteur Recyclage & Déchets",
+    relatedCasUsage: ["maintenance", "supply-chain-logistique"],
+    relatedServices: ["integration-donnees-etl-n8n", "support-maintenance"],
+  },
+  {
+    slug: "chimie-materiaux",
+    title: "Secteur Chimie & Matériaux",
+    relatedCasUsage: ["production-qualite", "securite"],
+    relatedServices: ["mlops", "securite"],
+  },
+  {
+    slug: "electronique",
+    title: "Secteur Électronique",
+    relatedCasUsage: ["production-qualite", "dsi-it"],
+    relatedServices: ["data-engineering", "mlops"],
+  },
+  {
+    slug: "retail-ecommerce",
+    title: "Secteur Retail & e-commerce",
+    relatedCasUsage: ["commercial-marketing", "service-client"],
+    relatedServices: ["ecommerce-automation", "marketing-automation"],
+  },
+  {
+    slug: "luxe-cosmetique",
+    title: "Secteur Luxe & Cosmétique",
+    relatedCasUsage: ["commercial-marketing", "service-client"],
+    relatedServices: ["marketing-automation", "crm-automation"],
+  },
+  {
+    slug: "mode-textile",
+    title: "Secteur Mode & Textile",
+    relatedCasUsage: ["supply-chain-logistique", "commercial-marketing"],
+    relatedServices: ["ecommerce-automation", "integration-donnees-etl-n8n"],
+  },
+  {
+    slug: "tourisme-loisirs",
+    title: "Secteur Tourisme & Loisirs",
+    relatedCasUsage: ["service-client", "commercial-marketing"],
+    relatedServices: ["marketing-automation", "agents-ia"],
+  },
+  {
+    slug: "hotellerie-restauration",
+    title: "Secteur Hôtellerie & Restauration",
+    relatedCasUsage: ["service-client", "achats-approvisionnements"],
+    relatedServices: ["service-client-helpdesk", "integration-donnees-etl-n8n"],
+  },
+  {
+    slug: "banque-assurance",
+    title: "Secteur Banque & Assurance",
+    relatedCasUsage: ["finance-comptabilite", "securite"],
+    relatedServices: ["rpa", "governance-rgpd-ai-act"],
+  },
+  {
+    slug: "telecom-medias",
+    title: "Secteur Télécom & Médias",
+    relatedCasUsage: ["service-client", "dsi-it"],
+    relatedServices: ["agents-ia", "automatisation-ia"],
+  },
+  {
+    slug: "services-b2b",
+    title: "Secteur Services B2B",
+    relatedCasUsage: ["pmo-gestion-de-projets", "commercial-marketing"],
+    relatedServices: ["erp-crm-dev", "sales-ops"],
+  },
+  {
+    slug: "saas-editeurs",
+    title: "Secteur SaaS & Éditeurs",
+    relatedCasUsage: ["dsi-it", "commercial-marketing"],
+    relatedServices: ["erp-crm-dev", "automatisation-ia"],
+  },
+  {
+    slug: "agences-esn",
+    title: "Secteur Agences & ESN",
+    relatedCasUsage: ["pmo-gestion-de-projets", "dsi-it"],
+    relatedServices: ["erp-crm-dev", "data-engineering"],
+  },
+  {
+    slug: "education",
+    title: "Secteur Éducation",
+    relatedCasUsage: ["rh", "juridique"],
+    relatedServices: ["gestion-documentaire-ged", "llm-rag"],
+  },
+  {
+    slug: "collectivites-parapublic",
+    title: "Secteur Collectivités & Parapublic",
+    relatedCasUsage: ["juridique", "securite"],
+    relatedServices: ["governance-rgpd-ai-act", "llm-rag"],
+  },
+]
+
+export const sectorSubpages: RouteItem[] = [
+  { slug: "processus-a-automatiser", title: "Processus à automatiser" },
+  { slug: "integrations-outils", title: "Intégrations d'outils" },
+  { slug: "kpi-a-optimiser", title: "KPI à optimiser" },
+  { slug: "cas-pratiques", title: "Cas pratiques" },
+  { slug: "conformite-reglementations", title: "Conformité et réglementations" },
+  { slug: "templates-et-sop", title: "Templates et SOP" },
+]
+
+export const guides: RouteItem[] = [
+  { slug: "checklist-audit-digital-pme", title: "Checklist audit digital PME" },
+  { slug: "sop-relances-automatiques", title: "SOP relances automatiques" },
+  { slug: "script-cold-email-rgpd", title: "Script cold email RGPD" },
+  { slug: "modele-kpi-finance", title: "Modèle KPI finance" },
+  { slug: "modele-kpi-production", title: "Modèle KPI production" },
+  { slug: "modele-kpi-logistique", title: "Modèle KPI logistique" },
+  { slug: "modele-kpi-commercial", title: "Modèle KPI commercial" },
+  { slug: "template-spec-fonctionnelle-automation", title: "Template spec fonctionnelle automation" },
+  { slug: "template-cahier-recette", title: "Template cahier de recette" },
+]
+
+export const questionHubEntries = [
+  { category: "definition", slug: "llm-rag", title: "Définition LLM RAG" },
+  { category: "definition", slug: "agent-ia", title: "Définition agent IA" },
+  { category: "definition", slug: "rpa", title: "Définition RPA" },
+  { category: "howto", slug: "automatiser-facturation-odoo", title: "Comment automatiser la facturation Odoo" },
+  { category: "howto", slug: "rag-sur-documents-rh", title: "RAG sur documents RH" },
+  { category: "howto", slug: "brancher-n8n-a-odoo", title: "Brancher n8n à Odoo" },
+  { category: "cout", slug: "prix-projet-ia-pme", title: "Prix projet IA PME" },
+  { category: "cout", slug: "budget-erp-crm-pme", title: "Budget ERP CRM PME" },
+  { category: "top", slug: "meilleurs-outils-automatisation-pme", title: "Meilleurs outils d'automatisation PME" },
+  { category: "alternatives", slug: "alternative-a-zapier", title: "Alternative à Zapier" },
+  { category: "problemes", slug: "erreurs-deploiement-rpa", title: "Erreurs déploiement RPA" },
+  { category: "tutoriels", slug: "workflow-n8n-email-vers-crm", title: "Tutoriel workflow n8n email vers CRM" },
+  { category: "conformite", slug: "ai-act-entreprise", title: "AI Act pour l'entreprise" },
+  { category: "conformite", slug: "rgpd-et-llm", title: "RGPD et LLM" },
+]
+
+export const comparatifs = [
+  { category: "erp", slug: "odoo-vs-sap-business-one", title: "Odoo vs SAP Business One" },
+  { category: "erp", slug: "odoo-vs-dolibarr", title: "Odoo vs Dolibarr" },
+  { category: "erp", slug: "odoo-vs-zoho", title: "Odoo vs Zoho" },
+  { category: "crm", slug: "hubspot-vs-odoo-crm", title: "HubSpot vs Odoo CRM" },
+  { category: "crm", slug: "pipedrive-vs-hubspot", title: "Pipedrive vs HubSpot" },
+  { category: "crm", slug: "salesforce-vs-odoo", title: "Salesforce vs Odoo" },
+  { category: "ecommerce", slug: "shopify-vs-woocommerce-vs-magento", title: "Shopify vs WooCommerce vs Magento" },
+  { category: "automatisation", slug: "n8n-vs-zapier-vs-make", title: "n8n vs Zapier vs Make" },
+  { category: "automatisation", slug: "rpa-vs-llm-agents", title: "RPA vs LLM Agents" },
+  { category: "bi", slug: "power-bi-vs-tableau-vs-looker", title: "Power BI vs Tableau vs Looker" },
+]
+
+export const glossaire = [
+  { slug: "llm", title: "Glossaire LLM" },
+  { slug: "rag", title: "Glossaire RAG" },
+  { slug: "agent", title: "Glossaire Agent" },
+  { slug: "prompt", title: "Glossaire Prompt" },
+  { slug: "vector-store", title: "Glossaire Vector Store" },
+  { slug: "etl", title: "Glossaire ETL" },
+  { slug: "ipass", title: "Glossaire iPaaS" },
+  { slug: "rpa", title: "Glossaire RPA" },
+  { slug: "ai-act", title: "Glossaire AI Act" },
+  { slug: "iso-27001", title: "Glossaire ISO 27001" },
+  { slug: "rgpd", title: "Glossaire RGPD" },
+  { slug: "erp", title: "Glossaire ERP" },
+  { slug: "crm", title: "Glossaire CRM" },
+  { slug: "wms-oms", title: "Glossaire WMS & OMS" },
+  { slug: "bi", title: "Glossaire BI" },
+]
+
+export const outils = [
+  { slug: "n8n", title: "Outil n8n" },
+  { slug: "odoo", title: "Outil Odoo" },
+  { slug: "hubspot", title: "Outil HubSpot" },
+  { slug: "make", title: "Outil Make" },
+  { slug: "zapier", title: "Outil Zapier" },
+  { slug: "mistral", title: "Outil Mistral" },
+  { slug: "openai", title: "Outil OpenAI" },
+  { slug: "azure-openai", title: "Outil Azure OpenAI" },
+  { slug: "power-bi", title: "Outil Power BI" },
+  { slug: "tableau", title: "Outil Tableau" },
+  { slug: "looker", title: "Outil Looker" },
+  { slug: "airbyte", title: "Outil Airbyte" },
+]
+
+export const corePages: RouteItem[] = [
+  { slug: "methode", title: "Méthode" },
+  { slug: "tarifs", title: "Tarifs" },
+  { slug: "faq", title: "FAQ" },
+  { slug: "contact", title: "Contact" },
+  { slug: "contact/merci", title: "Merci" },
+  { slug: "mentions-legales", title: "Mentions légales" },
+  { slug: "rgpd", title: "Politique de confidentialité" },
+  { slug: "cookies", title: "Politique cookies" },
+  { slug: "dpa", title: "DPA" },
+  { slug: "conditions-generales", title: "Conditions générales" },
+  { slug: "sitemap", title: "Plan du site" },
+  { slug: "status", title: "Status" },
+  { slug: "changelog", title: "Changelog" },
+  { slug: "blog", title: "Blog" },
+  { slug: "ressources/calculateur-roi", title: "Calculateur ROI" },
+]
+
+export const indexablePaths = new Set<string>([
+  "/",
+  "/tarifs",
+  "/methode",
+  "/faq",
+  "/contact",
+  "/sitemap",
+  "/mentions-legales",
+  "/rgpd",
+  "/cookies",
+  "/dpa",
+  "/conditions-generales",
+  "/services/audit-diagnostic",
+  "/services/automatisation-ia",
+  "/services/rpa",
+  "/services/llm-rag",
+  "/services/agents-ia",
+])
+
+export const homeRequiredLinks = {
+  services: ["/services/audit-diagnostic", "/services/automatisation-ia", "/services/erp-crm-dev"],
+  casUsage: [
+    "/cas-usage/commercial-marketing",
+    "/cas-usage/service-client",
+    "/cas-usage/finance-comptabilite",
+    "/cas-usage/achats-approvisionnements",
+    "/cas-usage/supply-chain-logistique",
+    "/cas-usage/production-qualite",
+  ],
+  sectors: [
+    "/secteurs/industrie",
+    "/secteurs/retail-ecommerce",
+    "/secteurs/banque-assurance",
+    "/secteurs/sante",
+    "/secteurs/energie-utilities",
+    "/secteurs/transport-logistique",
+    "/secteurs/saas-editeurs",
+    "/secteurs/services-b2b",
+  ],
+}
+
+export const servicesMap = new Map(services.map((item) => [item.slug, item]))
+export const casUsageMap = new Map(casUsage.map((item) => [item.slug, item]))
+export const sectorsMap = new Map(sectors.map((item) => [item.slug, item]))
+export const casUsageTasksMap = new Map(casUsageTasks.map((item) => [item.slug, item]))
+export const sectorSubpagesMap = new Map(sectorSubpages.map((item) => [item.slug, item]))
+export const guidesMap = new Map(guides.map((item) => [item.slug, item]))
+export const glossaireMap = new Map(glossaire.map((item) => [item.slug, item]))
+export const outilsMap = new Map(outils.map((item) => [item.slug, item]))
+export const comparatifsMap = new Map(comparatifs.map((item) => [item.slug, item]))
+export const questionHubMap = new Map(questionHubEntries.map((item) => [item.slug, item]))
+
+export const getAllRoutes = () => {
+  const routes = new Set<string>(["/"])
+
+  corePages.forEach((page) => {
+    routes.add(`/${page.slug}`)
+  })
+
+  routes.add("/services")
+  services.forEach((service) => {
+    routes.add(`/services/${service.slug}`)
+  })
+
+  routes.add("/cas-usage")
+  casUsage.forEach((item) => {
+    routes.add(`/cas-usage/${item.slug}`)
+    casUsageTasks.forEach((task) => {
+      routes.add(`/cas-usage/${item.slug}/${task.slug}`)
+    })
+  })
+
+  routes.add("/secteurs")
+  sectors.forEach((sector) => {
+    routes.add(`/secteurs/${sector.slug}`)
+    sectorSubpages.forEach((sub) => {
+      routes.add(`/secteurs/${sector.slug}/${sub.slug}`)
+    })
+  })
+
+  routes.add("/ressources")
+  routes.add("/ressources/guides")
+  guides.forEach((guide) => {
+    routes.add(`/ressources/guides/${guide.slug}`)
+  })
+
+  routes.add("/ressources/question-hub-ia")
+  questionHubEntries.forEach((entry) => {
+    routes.add(`/ressources/qh/${entry.category}/${entry.slug}`)
+  })
+
+  routes.add("/ressources/comparatifs")
+  const comparatifCategories = new Set<string>()
+  comparatifs.forEach((entry) => {
+    comparatifCategories.add(entry.category)
+    routes.add(`/ressources/comparatifs/${entry.category}/${entry.slug}`)
+  })
+  comparatifCategories.forEach((category) => {
+    routes.add(`/ressources/comparatifs/${category}`)
+  })
+
+  routes.add("/ressources/glossaire")
+  glossaire.forEach((entry) => {
+    routes.add(`/ressources/glossaire/${entry.slug}`)
+  })
+
+  routes.add("/ressources/outils")
+  outils.forEach((entry) => {
+    routes.add(`/ressources/outils/${entry.slug}`)
+  })
+
+  return Array.from(routes)
+}
+


### PR DESCRIPTION
## Summary
- add a comprehensive site structure configuration and navigation data to power mega-menu content, metadata, and sitemap generation
- introduce shared layout helpers including breadcrumbs, cookie banner, and simple page wrapper plus a home links section to satisfy internal linking requirements
- scaffold all requested services, cas d’usage, secteurs, ressources, and legal routes with placeholder content, breadcrumbs, and SEO utilities such as sitemap and robots endpoints

## Testing
- pnpm build *(fails: unable to fetch Google Fonts in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dfee3c6c2c8320a0c01e13ac7628a4