### PR TITLE
feat: implement minimal option a site structure

### DIFF
--- a/app/conditions-generales/page.tsx
+++ b/app/conditions-generales/page.tsx
@@ -3,25 +3,43 @@ import { SimplePageLayout } from "@/components/simple-page-layout"
 import { createPageMetadata } from "@/lib/metadata"
 
 export const metadata = createPageMetadata({
-  title: "Conditions générales",
+  title: "Conditions générales — Aperçu",
   path: "/conditions-generales",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function ConditionsGeneralesPage() {
   return (
     <SimplePageLayout
-      title="Conditions générales"
-      description="Contenu à venir."
+      title="Conditions générales — Aperçu"
+      description="Gabarit temporaire avant publication des conditions de service complètes."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "Conditions générales" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <p>
-        Voir également nos <Link className="underline" href="/mentions-legales">mentions légales</Link>.
-      </p>
+      <section className="ae-section">
+        <h2>Objet et définitions</h2>
+        <p>
+          Les clauses contractuelles définitives seront décrites ici. Ce texte agit comme substitut provisoire.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/mentions-legales">Mentions légales</Link>
+          <Link href="/politique-de-confidentialite">Politique de confidentialité</Link>
+        </div>
+      </section>
+
+      <section className="ae-section">
+        <h2>Engagements et support</h2>
+        <p>
+          Cette section présentera la structure de support, les obligations et les processus de résiliation lorsque le contenu
+          final sera prêt.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/services#support">Service — Support</Link>
+          <Link href="/contact">Contacter l'équipe</Link>
+        </div>
+      </section>
     </SimplePageLayout>
   )
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,35 +1,47 @@
 import Link from "next/link"
 import { SimplePageLayout } from "@/components/simple-page-layout"
-import { LinkSection } from "@/components/link-section"
 import { createPageMetadata } from "@/lib/metadata"
 
 export const metadata = createPageMetadata({
-  title: "Contact",
+  title: "Contact — Prise de rendez-vous",
   path: "/contact",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function ContactPage() {
   return (
     <SimplePageLayout
-      title="Contact"
-      description="Contenu à venir."
+      title="Contact — Prise de rendez-vous"
+      description="Espace temporaire pour centraliser les demandes avant la mise en ligne du formulaire définitif."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "Contact" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <LinkSection
-        title="Ressources utiles"
-        links={[
-          { href: "/faq", label: "Consulter la FAQ" },
-          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
-        ]}
-      />
-      <p>
-        Après envoi du formulaire, accédez à la page <Link className="underline" href="/contact/merci">merci</Link>.
-      </p>
+      <section className="ae-section">
+        <h2>Coordonnées provisoires</h2>
+        <p>
+          Les informations de contact finales seront publiées prochainement. D'ici là, utilisez ces liens pour explorer les
+          pages associées.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/services#support">Service — Support &amp; Pilotage</Link>
+          <Link href="/solutions#services-b2b">Solution — Services B2B</Link>
+          <Link href="/faq">Consulter la FAQ</Link>
+        </div>
+      </section>
+
+      <section className="ae-section">
+        <h2>Planifier un échange</h2>
+        <p>
+          L'équipe prépare un agenda partagé. En attendant, suivez les liens ci-dessous pour cadrer votre demande.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/methode">Voir la méthode</Link>
+          <Link href="/tarifs">Consulter les tarifs</Link>
+          <Link href="/ressources">Accéder aux ressources</Link>
+        </div>
+      </section>
     </SimplePageLayout>
   )
 }

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,35 +1,34 @@
 import Link from "next/link"
 import { SimplePageLayout } from "@/components/simple-page-layout"
-import { LinkSection } from "@/components/link-section"
 import { createPageMetadata } from "@/lib/metadata"
+import { faqAnchors, faqItems } from "@/lib/ae-content"
 
 export const metadata = createPageMetadata({
-  title: "FAQ",
+  title: "FAQ — Questions en préparation",
   path: "/faq",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function FAQPage() {
   return (
     <SimplePageLayout
-      title="FAQ"
-      description="Contenu à venir."
+      title="FAQ — Questions en préparation"
+      description="Cette foire aux questions est actuellement un gabarit destiné à accueillir les réponses finales."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "FAQ" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <LinkSection
-        title="Ressources utiles"
-        links={[
-          { href: "/services", label: "Découvrir les services" },
-          { href: "/contact", label: "Nous contacter" },
-        ]}
-      />
-      <p>
-        Explorez aussi le <Link className="underline" href="/ressources/question-hub-ia">Question-Hub IA</Link>.
-      </p>
+      {faqItems.map((item, index) => (
+        <section key={item.question} id={faqAnchors[index]?.id ?? `question-${index + 1}`} className="ae-section">
+          <h2>{item.question}</h2>
+          <p>{item.answer}</p>
+          <div className="ae-section-links">
+            <Link href="/services#audit">Voir le service Audit</Link>
+            <Link href="/tarifs">Consulter les tarifs</Link>
+          </div>
+        </section>
+      ))}
     </SimplePageLayout>
   )
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,11 +1,13 @@
 import type React from "react"
 import type { Metadata } from "next"
 import "./globals.css"
+import "../styles/ae-overrides.css"
 import { ParticleProvider } from "@/components/particle-context"
 import { CookieBanner } from "@/components/cookie-banner"
 import { BASE_URL } from "@/lib/site-structure"
 import { StructuredData } from "@/components/structured-data"
 import { HeadingIdProvider } from "@/components/heading-id-provider"
+import { AeNavPortalMount } from "@/components/ae-nav-portal-mount"
 
 const CANONICAL_URL = new URL("/", BASE_URL).toString()
 
@@ -45,7 +47,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="fr-FR" className="dark">
-      <body className="antialiased" suppressHydrationWarning>
+      <body className="antialiased ae-readable ae-dark" suppressHydrationWarning>
+        <AeNavPortalMount />
         <ParticleProvider>
           <HeadingIdProvider />
           {children}

--- a/app/mentions-legales/page.tsx
+++ b/app/mentions-legales/page.tsx
@@ -3,25 +3,43 @@ import { SimplePageLayout } from "@/components/simple-page-layout"
 import { createPageMetadata } from "@/lib/metadata"
 
 export const metadata = createPageMetadata({
-  title: "Mentions légales",
+  title: "Mentions légales — Version provisoire",
   path: "/mentions-legales",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function MentionsLegalesPage() {
   return (
     <SimplePageLayout
-      title="Mentions légales"
-      description="Contenu à venir."
+      title="Mentions légales — Version provisoire"
+      description="Cette page servira de support légal, les mentions complètes seront publiées à la mise en production."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "Mentions légales" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <p>
-        Pour toute demande, <Link className="underline" href="/contact">contactez-nous</Link>.
-      </p>
+      <section className="ae-section">
+        <h2>Identité de l'éditeur</h2>
+        <p>
+          Les informations juridiques détaillées de l'entité seront intégrées après validation. Les données actuelles sont
+          temporaires.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/contact">Contacter l'équipe</Link>
+          <Link href="/politique-de-confidentialite">Politique de confidentialité</Link>
+        </div>
+      </section>
+
+      <section className="ae-section">
+        <h2>Hébergement et responsabilité</h2>
+        <p>
+          Cette section présentera prochainement les informations relatives à l'hébergeur et aux limitations de responsabilité.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/conditions-generales">Conditions générales</Link>
+          <Link href="/sitemap">Plan du site</Link>
+        </div>
+      </section>
     </SimplePageLayout>
   )
 }

--- a/app/methode/page.tsx
+++ b/app/methode/page.tsx
@@ -1,35 +1,58 @@
 import Link from "next/link"
 import { SimplePageLayout } from "@/components/simple-page-layout"
-import { LinkSection } from "@/components/link-section"
 import { createPageMetadata } from "@/lib/metadata"
+import { servicesSections } from "@/lib/ae-content"
 
 export const metadata = createPageMetadata({
-  title: "Méthode",
+  title: "Méthode — Cadre expérimental",
   path: "/methode",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function MethodePage() {
   return (
     <SimplePageLayout
-      title="Méthode"
-      description="Contenu à venir."
+      title="Méthode — Cadre expérimental"
+      description="Itinéraire temporaire présentant l'articulation de la méthode à détailler."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "Méthode" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <LinkSection
-        title="Étapes suivantes"
-        links={[
-          { href: "/services", label: "Découvrir les services" },
-          { href: "/contact", label: "Prendre contact" },
-        ]}
-      />
-      <p>
-        Questions ? Consultez la <Link className="underline" href="/faq">FAQ</Link>.
-      </p>
+      <section className="ae-section">
+        <h2>Architecture de parcours</h2>
+        <p>
+          Ce contenu provisoire illustre la structure d'un cadrage IA, conçu pour accueillir les futures informations
+          méthodologiques.
+        </p>
+        <p className="ae-section-summary">
+          Chaque étape renverra bientôt vers des ressources dédiées et des livrables détaillés.
+        </p>
+        <div className="ae-section-links">
+          {servicesSections.map((section) => (
+            <Link key={section.id} href={`/services#${section.id}`}>
+              {section.title}
+            </Link>
+          ))}
+        </div>
+      </section>
+
+      <section className="ae-section">
+        <h2>Alignement et prochaines actions</h2>
+        <p>
+          Les compléments éditoriaux seront ajoutés pour documenter le pilotage, la gouvernance et le transfert de
+          compétences.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/tarifs">Consulter les options tarifaires</Link>
+          <Link href="/faq">Lire la FAQ</Link>
+          <Link href="/contact">Contacter l'équipe projet</Link>
+        </div>
+        <small>
+          Le guide détaillé sera publié après validation interne. Les pages services liées restent accessibles pour un aperçu
+          des futures offres.
+        </small>
+      </section>
     </SimplePageLayout>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,55 +1,57 @@
 "use client"
 
+import Link from "next/link"
 import { Header } from "@/components/header"
 import { Hero } from "@/components/hero"
-import { Services } from "@/components/services"
-import { Features } from "@/components/features"
-import { Stats } from "@/components/stats"
-import { Process } from "@/components/process"
-import { Portfolio } from "@/components/portfolio"
-import { Technologies } from "@/components/technologies"
-import { Team } from "@/components/team"
-import { Pricing } from "@/components/pricing"
-import { About } from "@/components/about"
-import { Testimonials } from "@/components/testimonials"
-import { Contact } from "@/components/contact"
 import { Footer } from "@/components/footer"
-import { Leva } from "leva"
-import { Insights } from "@/components/insights"
-import { Methodology } from "@/components/methodology"
-import { Resources } from "@/components/resources"
-import { Innovation } from "@/components/innovation"
-import { Partnerships } from "@/components/partnerships"
-import { Expertise } from "@/components/expertise"
-import { News } from "@/components/news"
-import { HomeLinks } from "@/components/home-links"
 
 export default function Home() {
   return (
     <div className="pt-24">
       <Header />
       <Hero />
-      <Services />
-      <Features />
-      <Stats />
-      <Process />
-      <Portfolio />
-      <Technologies />
-      <Team />
-      <Pricing />
-      <About />
-      <Testimonials />
-      <Innovation />
-      <Partnerships />
-      <Expertise />
-      <Insights />
-      <Methodology />
-      <Resources />
-      <HomeLinks />
-      <News />
-      <Contact />
+      <main className="relative z-10">
+        <div className="max-w-6xl mx-auto px-6 py-24 space-y-16">
+          <section className="ae-highlight-card">
+            <h2 className="text-3xl font-semibold mb-4">Préparez les parcours services</h2>
+            <p className="ae-muted">
+              Sélection temporaire de sections en construction pour orienter la future offre de services.
+            </p>
+            <div className="ae-section-links">
+              <Link href="/services#audit">Service — Audit</Link>
+              <Link href="/services#automatisation-ia">Service — Automatisation IA</Link>
+              <Link href="/services#erp-crm-dev">Service — ERP &amp; CRM</Link>
+            </div>
+          </section>
+
+          <section className="ae-highlight-card">
+            <h2 className="text-3xl font-semibold mb-4">Parcours solutions prioritaires</h2>
+            <p className="ae-muted">
+              Aperçu fictif des secteurs à relier prochainement aux offres détaillées.
+            </p>
+            <div className="ae-section-links">
+              <Link href="/solutions#commercial">Solution — Commercial</Link>
+              <Link href="/solutions#production">Solution — Production</Link>
+              <Link href="/solutions#logistique">Solution — Logistique</Link>
+              <Link href="/solutions#finance">Solution — Finance</Link>
+            </div>
+          </section>
+
+          <section className="ae-highlight-card">
+            <h2 className="text-3xl font-semibold mb-4">Étapes suivantes</h2>
+            <p className="ae-muted">
+              Naviguez vers les pages en cours de structuration pour compléter l'exploration.
+            </p>
+            <div className="ae-section-links">
+              <Link href="/methode">Découvrir la méthode</Link>
+              <Link href="/tarifs">Consulter les tarifs</Link>
+              <Link href="/ressources">Accéder aux ressources</Link>
+              <Link href="/contact">Écrire à l'équipe</Link>
+            </div>
+          </section>
+        </div>
+      </main>
       <Footer />
-      <Leva hidden />
     </div>
   )
 }

--- a/app/politique-de-confidentialite/page.tsx
+++ b/app/politique-de-confidentialite/page.tsx
@@ -1,0 +1,44 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+
+export const metadata = createPageMetadata({
+  title: "Politique de confidentialité — Aperçu",
+  path: "/politique-de-confidentialite",
+  description: "Page en construction.",
+})
+
+export default function PolitiqueDeConfidentialitePage() {
+  return (
+    <SimplePageLayout
+      title="Politique de confidentialité — Aperçu"
+      description="Document provisoire présentant la structure attendue de la politique de confidentialité."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Politique de confidentialité" },
+      ]}
+    >
+      <section className="ae-section">
+        <h2>Collecte et utilisation</h2>
+        <p>
+          Les informations détaillées relatives aux traitements seront ajoutées prochainement. Ce texte agit comme placeholder.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/mentions-legales">Mentions légales</Link>
+          <Link href="/conditions-generales">Conditions générales</Link>
+        </div>
+      </section>
+
+      <section className="ae-section" id="cookies">
+        <h2>Gestion des cookies</h2>
+        <p>
+          Cette section accueillera la politique cookies complète, incluant les modalités de consentement et de retrait.
+        </p>
+        <div className="ae-section-links">
+          <Link href="/contact">Demander une précision</Link>
+          <Link href="/sitemap">Plan du site</Link>
+        </div>
+      </section>
+    </SimplePageLayout>
+  )
+}

--- a/app/ressources/page.tsx
+++ b/app/ressources/page.tsx
@@ -1,45 +1,39 @@
 import Link from "next/link"
-import { createPageMetadata } from "@/lib/metadata"
 import { SimplePageLayout } from "@/components/simple-page-layout"
-
-const sections = [
-  { href: "/blog", label: "Blog" },
-  { href: "/ressources/guides", label: "Guides" },
-  { href: "/ressources/question-hub-ia", label: "Question-Hub IA" },
-  { href: "/ressources/comparatifs", label: "Comparatifs" },
-  { href: "/ressources/glossaire", label: "Glossaire" },
-  { href: "/ressources/outils", label: "Outils" },
-  { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
-]
+import { createPageMetadata } from "@/lib/metadata"
+import { resourcesSections } from "@/lib/ae-content"
 
 export const metadata = createPageMetadata({
-  title: "Ressources",
+  title: "Ressources — Blog, Guides, Question Hub, Glossaire",
   path: "/ressources",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function RessourcesPage() {
   return (
     <SimplePageLayout
-      title="Ressources"
-      description="Contenu à venir."
+      title="Ressources — Blog, Guides, Question Hub, Glossaire"
+      description="Aperçu provisoire des contenus éditoriaux en cours de production."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "Ressources" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <div className="grid gap-3 sm:grid-cols-2">
-        {sections.map((section) => (
-          <Link
-            key={section.href}
-            href={section.href}
-            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
-          >
-            {section.label}
-          </Link>
-        ))}
-      </div>
+      {resourcesSections.map((section) => (
+        <section key={section.id} id={section.id} className="ae-section">
+          <h2>{section.title}</h2>
+          <p>{section.description}</p>
+          <p className="ae-section-summary">{section.summary}</p>
+          <div className="ae-section-links">
+            {section.links.map((link) => (
+              <Link key={link.href} href={link.href}>
+                {link.label}
+              </Link>
+            ))}
+            {section.showFaqLink && <Link href="/faq">Consulter la FAQ</Link>}
+          </div>
+        </section>
+      ))}
     </SimplePageLayout>
   )
 }

--- a/app/robots.txt/route.ts
+++ b/app/robots.txt/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server"
 import { BASE_URL } from "@/lib/site-structure"
 
 export function GET() {
-  const body = `User-agent: *\nAllow: /\nSitemap: ${new URL("/sitemap.xml", BASE_URL).toString()}\nDisallow: /api`
+  const body = `User-agent: *\nAllow: /\nSitemap: ${new URL("/sitemap.xml", BASE_URL).toString()}\n`
 
   return new NextResponse(body, {
     headers: {

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,35 +1,43 @@
 import Link from "next/link"
-import { createPageMetadata } from "@/lib/metadata"
-import { services } from "@/lib/site-structure"
 import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { servicesSections } from "@/lib/ae-content"
+import { AeToc } from "@/components/ae-toc"
 
 export const metadata = createPageMetadata({
-  title: "Services",
+  title: "Services — Audit, Automatisation IA, ERP/CRM",
   path: "/services",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function ServicesPage() {
   return (
     <SimplePageLayout
-      title="Services"
-      description="Contenu à venir."
+      title="Services — Audit, Automatisation IA, ERP/CRM"
+      description="Panorama temporaire des services clés avant publication des contenus détaillés."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "Services" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <div className="grid gap-3 sm:grid-cols-2">
-        {services.map((service) => (
-          <Link
-            key={service.slug}
-            href={`/services/${service.slug}`}
-            className="rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-white/80 transition hover:text-white hover:border-white/30"
-          >
-            {service.title}
-          </Link>
-        ))}
+      <div className="ae-page-grid">
+        <AeToc
+          items={servicesSections.map((section) => ({ id: section.id, label: section.title }))}
+        />
+
+        <div className="ae-stack">
+          {servicesSections.map((section) => (
+            <section key={section.id} id={section.id} className="ae-section">
+              <h2>{section.title}</h2>
+              <p>{section.description}</p>
+              <p className="ae-section-summary">{section.summary}</p>
+              <div className="ae-section-links">
+                <Link href={section.solutionLink.href}>{section.solutionLink.label}</Link>
+                <Link href="/contact">Planifier un échange</Link>
+              </div>
+            </section>
+          ))}
+        </div>
       </div>
     </SimplePageLayout>
   )

--- a/app/sitemap.xml/route.ts
+++ b/app/sitemap.xml/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server"
-import { BASE_URL, getAllRoutes } from "@/lib/site-structure"
+import { BASE_URL } from "@/lib/site-structure"
+import { htmlSitemapEntries } from "@/lib/ae-content"
 
 export function GET() {
-  const urls = getAllRoutes()
-  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls
+  const body = `<?xml version="1.0" encoding="UTF-8"?>\n<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${htmlSitemapEntries
     .map((route) => `\n  <url><loc>${new URL(route, BASE_URL).toString()}</loc></url>`)
     .join("")}\n</urlset>`
 

--- a/app/sitemap/page.tsx
+++ b/app/sitemap/page.tsx
@@ -1,33 +1,28 @@
 import Link from "next/link"
 import { SimplePageLayout } from "@/components/simple-page-layout"
 import { createPageMetadata } from "@/lib/metadata"
-import { getAllRoutes } from "@/lib/site-structure"
-
-const routes = getAllRoutes().sort((a, b) => a.localeCompare(b))
+import { htmlSitemapEntries } from "@/lib/ae-content"
 
 export const metadata = createPageMetadata({
-  title: "Plan du site",
+  title: "Plan du site — Option A",
   path: "/sitemap",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function SitemapPage() {
   return (
     <SimplePageLayout
-      title="Plan du site"
-      description="Contenu à venir."
+      title="Plan du site — Option A"
+      description="Liste alphabétique des pages actuellement structurées."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "Plan du site" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <ul className="grid gap-2 sm:grid-cols-2">
-        {routes.map((route) => (
+      <ul className="ae-list">
+        {htmlSitemapEntries.map((route) => (
           <li key={route}>
-            <Link className="underline" href={route}>
-              {route}
-            </Link>
+            <Link href={route}>{route}</Link>
           </li>
         ))}
       </ul>

--- a/app/solutions/page.tsx
+++ b/app/solutions/page.tsx
@@ -1,0 +1,48 @@
+import Link from "next/link"
+import { SimplePageLayout } from "@/components/simple-page-layout"
+import { createPageMetadata } from "@/lib/metadata"
+import { servicesSections, solutionsSections } from "@/lib/ae-content"
+import { AeToc } from "@/components/ae-toc"
+
+const serviceLabelMap = new Map(servicesSections.map((section) => [section.id, section.title]))
+
+export const metadata = createPageMetadata({
+  title: "Solutions sectorielles",
+  path: "/solutions",
+  description: "Page en construction.",
+})
+
+export default function SolutionsPage() {
+  return (
+    <SimplePageLayout
+      title="Solutions sectorielles"
+      description="Cartographie temporaire des verticales adressées avant publication des cas détaillés."
+      breadcrumbs={[
+        { label: "Accueil", href: "/" },
+        { label: "Solutions" },
+      ]}
+    >
+      <div className="ae-page-grid">
+        <AeToc items={solutionsSections.map((section) => ({ id: section.id, label: section.title }))} />
+
+        <div className="ae-stack">
+          {solutionsSections.map((section) => (
+            <section key={section.id} id={section.id} className="ae-section">
+              <h2>{section.title}</h2>
+              <p>{section.description}</p>
+              <p className="ae-section-summary">{section.summary}</p>
+              <div className="ae-section-links">
+                {section.relatedServices.map((serviceId) => (
+                  <Link key={serviceId} href={`/services#${serviceId}`}>
+                    {serviceLabelMap.get(serviceId) ?? "Service associé"}
+                  </Link>
+                ))}
+                <Link href="/tarifs">Explorer les tarifs</Link>
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
+    </SimplePageLayout>
+  )
+}

--- a/app/tarifs/page.tsx
+++ b/app/tarifs/page.tsx
@@ -1,35 +1,48 @@
 import Link from "next/link"
 import { SimplePageLayout } from "@/components/simple-page-layout"
-import { LinkSection } from "@/components/link-section"
 import { createPageMetadata } from "@/lib/metadata"
+import { offerCatalog, servicesSections, solutionsSections } from "@/lib/ae-content"
+
+const serviceMap = new Map(servicesSections.map((section) => [section.id, section.title]))
+const solutionMap = new Map(solutionsSections.map((section) => [section.id, section.title]))
 
 export const metadata = createPageMetadata({
-  title: "Tarifs",
+  title: "Tarifs — Catalogue provisoire",
   path: "/tarifs",
-  description: "Contenu à venir.",
+  description: "Page en construction.",
 })
 
 export default function TarifsPage() {
   return (
     <SimplePageLayout
-      title="Tarifs"
-      description="Contenu à venir."
+      title="Tarifs — Catalogue provisoire"
+      description="Présentation temporaire de trois offres type avant publication des conditions complètes."
       breadcrumbs={[
         { label: "Accueil", href: "/" },
         { label: "Tarifs" },
       ]}
     >
-      <p>Contenu à venir.</p>
-      <LinkSection
-        title="Outils utiles"
-        links={[
-          { href: "/ressources/calculateur-roi", label: "Calculateur ROI" },
-          { href: "/contact", label: "Obtenir une estimation" },
-        ]}
-      />
-      <p>
-        Explorez aussi nos <Link className="underline" href="/services">services</Link>.
-      </p>
+      {offerCatalog.map((offer) => (
+        <section key={offer.id} id={offer.id} className="ae-section">
+          <h2>{offer.title}</h2>
+          <p>{offer.description}</p>
+          <p className="ae-section-summary">Budget indicatif : {offer.price}</p>
+          <div className="ae-section-links">
+            {offer.serviceLinks.map((serviceId) => (
+              <Link key={serviceId} href={`/services#${serviceId}`}>
+                {serviceMap.get(serviceId) ?? "Service associé"}
+              </Link>
+            ))}
+            {offer.solutionLinks.map((solutionId) => (
+              <Link key={solutionId} href={`/solutions#${solutionId}`}>
+                {solutionMap.get(solutionId) ?? "Solution associée"}
+              </Link>
+            ))}
+            <Link href="/faq">Questions fréquentes</Link>
+            <Link href="/contact">Demander un devis</Link>
+          </div>
+        </section>
+      ))}
     </SimplePageLayout>
   )
 }

--- a/components/ae-nav-portal-mount.tsx
+++ b/components/ae-nav-portal-mount.tsx
@@ -1,0 +1,30 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+
+export const AeNavPortalMount = () => {
+  const createdRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    if (typeof document === "undefined") {
+      return
+    }
+
+    let portal = document.getElementById("ae-nav-portal") as HTMLDivElement | null
+
+    if (!portal) {
+      portal = document.createElement("div")
+      portal.setAttribute("id", "ae-nav-portal")
+      document.body.appendChild(portal)
+      createdRef.current = portal
+    }
+
+    return () => {
+      if (createdRef.current && createdRef.current.parentElement) {
+        createdRef.current.parentElement.removeChild(createdRef.current)
+      }
+    }
+  }, [])
+
+  return null
+}

--- a/components/ae-toc.tsx
+++ b/components/ae-toc.tsx
@@ -1,0 +1,34 @@
+import Link from "next/link"
+
+type TocItem = {
+  id: string
+  label: string
+  href?: string
+}
+
+type TocProps = {
+  title?: string
+  items: TocItem[]
+}
+
+export const AeToc = ({ title = "Sommaire", items }: TocProps) => {
+  if (!items.length) {
+    return null
+  }
+
+  return (
+    <nav className="ae-toc" aria-label={title}>
+      <h2>{title}</h2>
+      <ul className="ae-list">
+        {items.map((item) => {
+          const href = item.href ?? `#${item.id}`
+          return (
+            <li key={item.id}>
+              <Link href={href}>{item.label}</Link>
+            </li>
+          )
+        })}
+      </ul>
+    </nav>
+  )
+}

--- a/components/breadcrumbs.tsx
+++ b/components/breadcrumbs.tsx
@@ -11,7 +11,7 @@ export const Breadcrumbs = ({ items }: { items: BreadcrumbItem[] }) => {
   }
 
   return (
-    <nav aria-label="Fil d'Ariane" className="text-sm text-white/70">
+    <nav aria-label="Fil d'Ariane" className="ae-breadcrumbs">
       <ol className="flex flex-wrap items-center gap-1">
         {items.map((item, index) => {
           const isLast = index === items.length - 1

--- a/components/cookie-banner.tsx
+++ b/components/cookie-banner.tsx
@@ -28,7 +28,8 @@ export const CookieBanner = () => {
         <h2 className="text-lg font-semibold mb-2">Cookies</h2>
         <p className="text-sm text-white/80">
           Nous utilisons des cookies nécessitant votre consentement pour les mesures d'audience et le marketing. Vous pouvez en
-          savoir plus dans notre <Link className="underline" href="/cookies">politique cookies</Link>.
+          savoir plus dans notre <Link className="underline" href="/politique-de-confidentialite#cookies">politique de
+          confidentialité</Link>.
         </p>
         <div className="mt-4 flex flex-wrap gap-3">
           <button

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,7 +1,8 @@
 "use client"
 
 import Link from "next/link"
-import { footerLinks } from "@/lib/navigation"
+import { footerLinks, primaryNav } from "@/lib/navigation"
+import { plusNavItems } from "@/lib/ae-content"
 import { useParticles } from "./particle-context"
 import { Button } from "./ui/button"
 import { Mail, Phone, MapPin } from "lucide-react"
@@ -47,27 +48,29 @@ export function Footer() {
           <div className="space-y-4 animate-in fade-in slide-in-from-bottom duration-1000 delay-200">
             <h4 className="text-lg font-semibold">Navigation</h4>
             <div className="flex flex-col gap-3 text-sm">
-              {footerLinks.slice(0, 5).map((item) => (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  onMouseEnter={() => setHovering(true)}
-                  onMouseLeave={() => setHovering(false)}
-                  className="text-white/70 hover:text-white transition-all duration-500 hover:translate-x-1 inline-block relative group"
-                >
-                  <span className="relative">
-                    {item.label}
-                    <span className="absolute -bottom-0.5 left-0 w-0 h-[1px] bg-white/50 transition-all duration-500 group-hover:w-full"></span>
-                  </span>
-                </Link>
-              ))}
+              {primaryNav
+                .filter((item) => item.label !== "Plus")
+                .map((item) => (
+                  <Link
+                    key={item.href}
+                    href={item.href}
+                    onMouseEnter={() => setHovering(true)}
+                    onMouseLeave={() => setHovering(false)}
+                    className="text-white/70 hover:text-white transition-all duration-500 hover:translate-x-1 inline-block relative group"
+                  >
+                    <span className="relative">
+                      {item.label}
+                      <span className="absolute -bottom-0.5 left-0 w-0 h-[1px] bg-white/50 transition-all duration-500 group-hover:w-full"></span>
+                    </span>
+                  </Link>
+                ))}
             </div>
           </div>
 
           <div className="space-y-4 animate-in fade-in slide-in-from-bottom duration-1000 delay-300">
-            <h4 className="text-lg font-semibold">Services</h4>
+            <h4 className="text-lg font-semibold">Plus</h4>
             <div className="flex flex-col gap-3 text-sm">
-              {footerLinks.slice(5, 10).map((item) => (
+              {plusNavItems.map((item) => (
                 <Link
                   key={item.href}
                   href={item.href}
@@ -122,25 +125,15 @@ export function Footer() {
           <p className="transition-colors duration-500 hover:text-white/80">
             © {new Date().getFullYear()} Aegens. Tous droits réservés.
           </p>
-          <div className="flex gap-6">
-            <Link href="/mentions-legales" className="hover:text-white transition-all duration-500 relative group">
-              <span className="relative">
-                Mentions légales
-                <span className="absolute -bottom-0.5 left-0 w-0 h-[1px] bg-white/50 transition-all duration-500 group-hover:w-full"></span>
-              </span>
-            </Link>
-            <Link href="/confidentialite" className="hover:text-white transition-all duration-500 relative group">
-              <span className="relative">
-                Confidentialité
-                <span className="absolute -bottom-0.5 left-0 w-0 h-[1px] bg-white/50 transition-all duration-500 group-hover:w-full"></span>
-              </span>
-            </Link>
-            <Link href="/cookies" className="hover:text-white transition-all duration-500 relative group">
-              <span className="relative">
-                Cookies
-                <span className="absolute -bottom-0.5 left-0 w-0 h-[1px] bg-white/50 transition-all duration-500 group-hover:w-full"></span>
-              </span>
-            </Link>
+          <div className="flex gap-6 flex-wrap justify-center md:justify-end">
+            {footerLinks.map((item) => (
+              <Link key={item.href} href={item.href} className="hover:text-white transition-all duration-500 relative group">
+                <span className="relative">
+                  {item.label}
+                  <span className="absolute -bottom-0.5 left-0 w-0 h-[1px] bg-white/50 transition-all duration-500 group-hover:w-full"></span>
+                </span>
+              </Link>
+            ))}
           </div>
         </div>
       </div>

--- a/components/gl/index.tsx
+++ b/components/gl/index.tsx
@@ -1,6 +1,5 @@
 import { Effects } from "@react-three/drei"
 import { Canvas } from "@react-three/fiber"
-import { useControls } from "leva"
 import { Particles } from "./particles"
 import { VignetteShader } from "./shaders/vignetteShader"
 
@@ -17,41 +16,22 @@ export const GL = ({
   backgroundClickCenter: { x: number; y: number } | null
   backgroundClickProgress: number // Added backgroundClickProgress prop
 }) => {
-  const {
-    speed,
-    focus,
-    aperture,
-    size,
-    noiseScale,
-    noiseIntensity,
-    timeScale,
-    pointSize,
-    opacity,
-    planeScale,
-    vignetteDarkness,
-    vignetteOffset,
-    useManualTime,
-    manualTime,
-  } = useControls("Particle System", {
-    speed: { value: 1.0, min: 0, max: 2, step: 0.01 },
-    noiseScale: { value: 0.6, min: 0.1, max: 5, step: 0.1 },
-    noiseIntensity: { value: 0.52, min: 0, max: 2, step: 0.01 },
-    timeScale: { value: 1, min: 0, max: 2, step: 0.01 },
-    focus: { value: 3.8, min: 0.1, max: 20, step: 0.1 },
-    aperture: { value: 1.79, min: 0, max: 2, step: 0.01 },
-    pointSize: { value: 10.0, min: 0.1, max: 10, step: 0.1 },
-    opacity: { value: 0.8, min: 0, max: 1, step: 0.01 },
-    planeScale: { value: 10.0, min: 0.1, max: 10, step: 0.1 },
-    size: {
-      value: 512,
-      options: [256, 512, 1024],
-    },
-    showDebugPlane: { value: false },
-    vignetteDarkness: { value: 1.5, min: 0, max: 2, step: 0.1 },
-    vignetteOffset: { value: 0.4, min: 0, max: 2, step: 0.1 },
-    useManualTime: { value: false },
-    manualTime: { value: 0, min: 0, max: 50, step: 0.01 },
-  })
+  const config = {
+    speed: 1,
+    focus: 3.8,
+    aperture: 1.79,
+    size: 512,
+    noiseScale: 0.6,
+    noiseIntensity: 0.52,
+    timeScale: 1,
+    pointSize: 10,
+    opacity: 0.8,
+    planeScale: 10,
+    vignetteDarkness: 1.5,
+    vignetteOffset: 0.4,
+    useManualTime: false,
+    manualTime: 0,
+  }
   return (
     <div id="webgl">
       <Canvas
@@ -65,18 +45,18 @@ export const GL = ({
         {/* <Perf position="top-left" /> */}
         <color attach="background" args={["#000"]} />
         <Particles
-          speed={speed}
-          aperture={aperture}
-          focus={focus}
-          size={size}
-          noiseScale={noiseScale}
-          noiseIntensity={noiseIntensity}
-          timeScale={timeScale}
-          pointSize={pointSize}
-          opacity={opacity}
-          planeScale={planeScale}
-          useManualTime={useManualTime}
-          manualTime={manualTime}
+          speed={config.speed}
+          aperture={config.aperture}
+          focus={config.focus}
+          size={config.size}
+          noiseScale={config.noiseScale}
+          noiseIntensity={config.noiseIntensity}
+          timeScale={config.timeScale}
+          pointSize={config.pointSize}
+          opacity={config.opacity}
+          planeScale={config.planeScale}
+          useManualTime={config.useManualTime}
+          manualTime={config.manualTime}
           introspect={hovering}
           mousePosition={mousePosition}
           clickRipples={clickRipples}
@@ -86,8 +66,8 @@ export const GL = ({
         <Effects multisampling={0} disableGamma>
           <shaderPass
             args={[VignetteShader]}
-            uniforms-darkness-value={vignetteDarkness}
-            uniforms-offset-value={vignetteOffset}
+            uniforms-darkness-value={config.vignetteDarkness}
+            uniforms-offset-value={config.vignetteOffset}
           />
         </Effects>
       </Canvas>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -6,9 +6,8 @@ import { NavigationDropdown } from "./navigation-dropdown"
 import { primaryNav } from "@/lib/navigation"
 
 export const Header = () => {
-  const mainNavItems = primaryNav.filter((item) =>
-    ["Méthode", "Services", "Ressources", "Contact"].includes(item.label),
-  )
+  const mainNavItems = primaryNav.filter((item) => item.label !== "Plus")
+  const plusItem = primaryNav.find((item) => item.label === "Plus")
 
   return (
     <div className="fixed z-[9999] top-0 left-0 w-full">
@@ -46,9 +45,11 @@ export const Header = () => {
                 </div>
               )
             })}
-            <div className="animate-in fade-in duration-1000 delay-700">
-              <NavigationDropdown />
-            </div>
+            {plusItem && (
+              <div className="animate-in fade-in duration-1000 delay-700">
+                <NavigationDropdown />
+              </div>
+            )}
           </nav>
 
           <div className="lg:hidden animate-in fade-in duration-1000 delay-300">

--- a/components/navigation-dropdown.tsx
+++ b/components/navigation-dropdown.tsx
@@ -1,47 +1,161 @@
 "use client"
 
-import { useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import Link from "next/link"
+import { createPortal } from "react-dom"
 import { ChevronDown } from "lucide-react"
-import { primaryNav } from "@/lib/navigation"
+import { plusNavItems } from "@/lib/ae-content"
+
+type DropdownPosition = {
+  top: number
+  left: number
+  width: number
+}
+
+const getPortalElement = () => (typeof document !== "undefined" ? document.getElementById("ae-nav-portal") : null)
 
 export const NavigationDropdown = () => {
   const [isOpen, setIsOpen] = useState(false)
+  const [position, setPosition] = useState<DropdownPosition | null>(null)
+  const buttonRef = useRef<HTMLButtonElement | null>(null)
+  const panelRef = useRef<HTMLDivElement | null>(null)
 
-  const menuItems = primaryNav.filter((item) => !["Accueil", "Services", "Ressources", "Contact"].includes(item.label))
+  const updatePosition = useCallback(() => {
+    if (!buttonRef.current) {
+      return
+    }
+
+    const rect = buttonRef.current.getBoundingClientRect()
+    setPosition({
+      top: rect.bottom + 12,
+      left: Math.min(rect.left, Math.max(16, window.innerWidth - 320)),
+      width: rect.width,
+    })
+  }, [])
+
+  const closeMenu = useCallback(() => {
+    setIsOpen(false)
+  }, [])
+
+  useEffect(() => {
+    if (!isOpen) {
+      return
+    }
+
+    updatePosition()
+
+    const handleClick = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (
+        panelRef.current &&
+        !panelRef.current.contains(target) &&
+        buttonRef.current &&
+        !buttonRef.current.contains(target)
+      ) {
+        closeMenu()
+      }
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault()
+        closeMenu()
+      }
+
+      if (event.key === "Tab" && panelRef.current) {
+        const focusable = panelRef.current.querySelectorAll<HTMLElement>("a, button")
+        if (focusable.length === 0) {
+          return
+        }
+
+        const first = focusable[0]
+        const last = focusable[focusable.length - 1]
+
+        if (!event.shiftKey && document.activeElement === last) {
+          event.preventDefault()
+          first.focus()
+        }
+
+        if (event.shiftKey && document.activeElement === first) {
+          event.preventDefault()
+          last.focus()
+        }
+      }
+    }
+
+    const handleResize = () => {
+      updatePosition()
+    }
+
+    document.addEventListener("mousedown", handleClick)
+    document.addEventListener("keydown", handleKeyDown)
+    window.addEventListener("resize", handleResize)
+    window.addEventListener("scroll", handleResize, true)
+
+    return () => {
+      document.removeEventListener("mousedown", handleClick)
+      document.removeEventListener("keydown", handleKeyDown)
+      window.removeEventListener("resize", handleResize)
+      window.removeEventListener("scroll", handleResize, true)
+    }
+  }, [closeMenu, isOpen, updatePosition])
+
+  useEffect(() => {
+    if (!isOpen || !panelRef.current) {
+      return
+    }
+
+    const focusable = panelRef.current.querySelectorAll<HTMLElement>("a, button")
+    focusable[0]?.focus()
+  }, [isOpen])
+
+  const portal = useMemo(() => getPortalElement(), [])
 
   return (
     <div className="relative">
       <button
-        onClick={() => setIsOpen(!isOpen)}
+        ref={buttonRef}
+        onClick={() => {
+          if (isOpen) {
+            closeMenu()
+            return
+          }
+          setIsOpen(true)
+          requestAnimationFrame(() => {
+            updatePosition()
+          })
+        }}
         className="flex items-center gap-2 text-lg font-semibold text-white/90 hover:text-white transition-colors duration-200"
         aria-expanded={isOpen}
         aria-haspopup="true"
+        aria-controls="ae-nav-dropdown"
       >
         Plus
         <ChevronDown className={`w-5 h-5 transition-transform duration-300 ${isOpen ? "rotate-180" : ""}`} />
       </button>
 
-      {isOpen && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
-          <div className="absolute top-full right-0 mt-4 w-72 bg-black/95 backdrop-blur-xl border border-white/10 rounded-lg shadow-2xl overflow-hidden z-50">
-            <div className="py-2">
-              {menuItems.map((item, index) => (
-                <Link
-                  key={item.label}
-                  href={item.href}
-                  onClick={() => setIsOpen(false)}
-                  className="block px-6 py-4 text-white/90 hover:text-white hover:bg-white/5 transition-all duration-200 border-b border-white/5 last:border-b-0"
-                >
-                  <span className="font-semibold text-lg">{item.label}</span>
-                  {item.description && <span className="block text-base text-white/60 mt-1">{item.description}</span>}
-                </Link>
-              ))}
-            </div>
-          </div>
-        </>
-      )}
+      {isOpen && portal && position &&
+        createPortal(
+          <div
+            id="ae-nav-dropdown"
+            ref={panelRef}
+            role="menu"
+            className="ae-dropdown"
+            style={{ top: position.top, left: position.left, minWidth: Math.max(position.width, 240) }}
+          >
+            {plusNavItems.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                role="menuitem"
+                onClick={() => closeMenu()}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </div>,
+          portal,
+        )}
     </div>
   )
 }

--- a/components/simple-page-layout.tsx
+++ b/components/simple-page-layout.tsx
@@ -15,13 +15,13 @@ export const SimplePageLayout = ({ title, description, breadcrumbs, children }: 
     <div className="bg-black text-white min-h-screen">
       <Header />
       <main className="pt-44 pb-20">
-        <div className="max-w-5xl mx-auto px-6 space-y-8">
+        <div className="max-w-6xl mx-auto px-6 space-y-8">
           {breadcrumbs && <Breadcrumbs items={breadcrumbs} />}
           <div className="space-y-4">
             <h1 className="text-4xl">{title}</h1>
-            {description && <div className="text-white/80">{description}</div>}
+            {description && <div className="ae-muted">{description}</div>}
           </div>
-          <div className="space-y-6 text-white/90">{children}</div>
+          <div className="ae-stack">{children}</div>
         </div>
       </main>
       <Footer />

--- a/lib/ae-content.ts
+++ b/lib/ae-content.ts
@@ -1,0 +1,290 @@
+export const SEO_INDEX_ALL = false as const
+
+export type AePage = {
+  path: string
+  label: string
+  indexable?: boolean
+}
+
+export const optionAPages: AePage[] = [
+  { path: "/", label: "Accueil", indexable: true },
+  { path: "/methode", label: "Méthode", indexable: true },
+  { path: "/services", label: "Services", indexable: true },
+  { path: "/solutions", label: "Solutions", indexable: true },
+  { path: "/ressources", label: "Ressources", indexable: true },
+  { path: "/tarifs", label: "Tarifs", indexable: true },
+  { path: "/faq", label: "FAQ", indexable: true },
+  { path: "/contact", label: "Contact", indexable: true },
+  { path: "/mentions-legales", label: "Mentions légales", indexable: true },
+  {
+    path: "/politique-de-confidentialite",
+    label: "Politique de confidentialité",
+    indexable: true,
+  },
+  { path: "/conditions-generales", label: "Conditions générales", indexable: true },
+  { path: "/sitemap", label: "Plan du site", indexable: true },
+]
+
+export const htmlSitemapEntries = optionAPages
+  .filter((page) => page.indexable !== false)
+  .map((page) => page.path)
+  .sort((a, b) => a.localeCompare(b))
+
+export const indexablePaths = new Set(optionAPages.filter((page) => page.indexable !== false).map((page) => page.path))
+
+export type AeNavLink = { label: string; href: string }
+
+export const plusNavItems: AeNavLink[] = [
+  { label: "Solutions", href: "/solutions" },
+  { label: "Ressources", href: "/ressources" },
+  { label: "FAQ", href: "/faq" },
+  { label: "Mentions légales", href: "/mentions-legales" },
+  { label: "Politique de confidentialité", href: "/politique-de-confidentialite" },
+  { label: "Conditions générales", href: "/conditions-generales" },
+  { label: "Plan du site", href: "/sitemap" },
+]
+
+export const footerLegalLinks: AeNavLink[] = [
+  { label: "Mentions légales", href: "/mentions-legales" },
+  { label: "Politique de confidentialité", href: "/politique-de-confidentialite" },
+  { label: "Conditions générales", href: "/conditions-generales" },
+  { label: "Plan du site", href: "/sitemap" },
+]
+
+export type AeServiceSection = {
+  id: string
+  title: string
+  description: string
+  summary: string
+  solutionLink: AeNavLink
+}
+
+export const servicesSections: AeServiceSection[] = [
+  {
+    id: "audit",
+    title: "Audit & Diagnostic IA",
+    description: "Texte de placeholder pour présenter un diagnostic stratégique futur.",
+    summary: "Synthèse provisoire décrivant la préparation d'un audit IA.",
+    solutionLink: { href: "/solutions#finance", label: "Voir la solution Finance" },
+  },
+  {
+    id: "automatisation-ia",
+    title: "Automatisation IA",
+    description: "Contenu temporaire détaillant les parcours d'automatisation à définir.",
+    summary: "Résumé fictif sur la mise en place d'automatisations pilotées par l'IA.",
+    solutionLink: { href: "/solutions#logistique", label: "Explorer la solution Logistique" },
+  },
+  {
+    id: "erp-crm-dev",
+    title: "ERP & CRM sur mesure",
+    description: "Placeholder décrivant une future offre d'intégration métier personnalisée.",
+    summary: "Aperçu fictif d'un socle ERP/CRM évolutif pour les équipes.",
+    solutionLink: { href: "/solutions#commercial", label: "Accéder à la solution Commerciale" },
+  },
+  {
+    id: "formation",
+    title: "Formation & Adoption",
+    description: "Brouillon de texte indiquant l'arrivée prochaine d'un catalogue de formations.",
+    summary: "Capsule fictive sur l'accompagnement pédagogique en continu.",
+    solutionLink: { href: "/solutions#rh", label: "Solutions Ressources humaines" },
+  },
+  {
+    id: "support",
+    title: "Support & Pilotage",
+    description: "Placeholder pour décrire une gouvernance et un support évolutif.",
+    summary: "Note synthétique en attente sur le suivi opérationnel.",
+    solutionLink: { href: "/solutions#services-b2b", label: "Solutions Services B2B" },
+  },
+]
+
+export type AeSolutionSection = {
+  id: string
+  title: string
+  description: string
+  summary: string
+  relatedServices: string[]
+}
+
+export const solutionsSections: AeSolutionSection[] = [
+  {
+    id: "commercial",
+    title: "Solutions Commercial",
+    description: "Placeholder décrivant les parcours commerciaux à définir.",
+    summary: "Vue provisoire d'une orchestration des cycles commerciaux.",
+    relatedServices: ["erp-crm-dev", "automatisation-ia"],
+  },
+  {
+    id: "finance",
+    title: "Solutions Finance",
+    description: "Texte temporaire dédié aux prochaines offres financières.",
+    summary: "Aperçu fictif de la consolidation et du reporting automatisé.",
+    relatedServices: ["audit", "support"],
+  },
+  {
+    id: "production",
+    title: "Solutions Production",
+    description: "Placeholder sur la digitalisation des opérations de production.",
+    summary: "Extrait provisoire sur un pilotage d'ateliers augmentés.",
+    relatedServices: ["automatisation-ia", "support"],
+  },
+  {
+    id: "logistique",
+    title: "Solutions Logistique",
+    description: "Texte temporaire sur l'optimisation de la chaîne logistique.",
+    summary: "Synthèse fictive des flux synchronisés et automatisés.",
+    relatedServices: ["automatisation-ia", "formation"],
+  },
+  {
+    id: "rh",
+    title: "Solutions Ressources humaines",
+    description: "Placeholder dédié aux prochaines offres RH.",
+    summary: "Note provisoire sur le suivi des talents et de l'expérience collaborateur.",
+    relatedServices: ["formation", "support"],
+  },
+  {
+    id: "industrie",
+    title: "Solutions Industrie",
+    description: "Texte temporaire pour un dispositif industriel modulable.",
+    summary: "Aperçu fictif d'une usine connectée à venir.",
+    relatedServices: ["audit", "automatisation-ia"],
+  },
+  {
+    id: "retail-ecommerce",
+    title: "Solutions Retail & e-commerce",
+    description: "Placeholder décrivant la personnalisation omnicanale envisagée.",
+    summary: "Vue provisoire sur des parcours clients synchronisés.",
+    relatedServices: ["erp-crm-dev", "formation"],
+  },
+  {
+    id: "services-b2b",
+    title: "Solutions Services B2B",
+    description: "Texte temporaire autour d'une future plateforme de services.",
+    summary: "Synthèse fictive d'un dispositif B2B orchestré.",
+    relatedServices: ["support", "audit"],
+  },
+  {
+    id: "sante",
+    title: "Solutions Santé",
+    description: "Placeholder sur les parcours patients augmentés en préparation.",
+    summary: "Note provisoire sur la coordination des soins et la conformité.",
+    relatedServices: ["formation", "support"],
+  },
+  {
+    id: "transport-energie",
+    title: "Solutions Transport & Énergie",
+    description: "Texte temporaire concernant l'optimisation des réseaux.",
+    summary: "Synthèse fictive d'une supervision énergétique augmentée.",
+    relatedServices: ["automatisation-ia", "support"],
+  },
+]
+
+export type AeResourceSection = {
+  id: string
+  title: string
+  description: string
+  summary: string
+  links: AeNavLink[]
+  showFaqLink?: boolean
+}
+
+export const resourcesSections: AeResourceSection[] = [
+  {
+    id: "blog",
+    title: "Blog",
+    description: "Placeholder pour les articles à venir.",
+    summary: "Teaser fictif de futurs billets d'inspiration.",
+    links: [{ href: "/solutions#commercial", label: "Solutions Commercial" }],
+    showFaqLink: true,
+  },
+  {
+    id: "guides",
+    title: "Guides",
+    description: "Texte temporaire pour des parcours guidés à concevoir.",
+    summary: "Sommaire fictif de guides pratiques.",
+    links: [{ href: "/services#audit", label: "Service Audit" }],
+    showFaqLink: true,
+  },
+  {
+    id: "question-hub",
+    title: "Question Hub",
+    description: "Placeholder pour un centre de questions IA.",
+    summary: "Aperçu provisoire de futures réponses détaillées.",
+    links: [{ href: "/solutions#rh", label: "Solutions RH" }],
+    showFaqLink: true,
+  },
+  {
+    id: "glossaire",
+    title: "Glossaire",
+    description: "Texte temporaire présentant un lexique à venir.",
+    summary: "Note fictive sur un vocabulaire IA unifié.",
+    links: [{ href: "/services#automatisation-ia", label: "Service Automatisation" }],
+    showFaqLink: false,
+  },
+]
+
+export type AeOffer = {
+  id: string
+  title: string
+  description: string
+  price: string
+  serviceLinks: string[]
+  solutionLinks: string[]
+}
+
+export const offerCatalog: AeOffer[] = [
+  {
+    id: "atelier",
+    title: "Atelier découverte",
+    description: "Formule fictive pour cadrer un projet IA.",
+    price: "À partir de 2 000 €",
+    serviceLinks: ["audit"],
+    solutionLinks: ["commercial"],
+  },
+  {
+    id: "programme",
+    title: "Programme accélération",
+    description: "Offre temporaire pour prototyper et automatiser.",
+    price: "À partir de 6 500 €",
+    serviceLinks: ["automatisation-ia", "formation"],
+    solutionLinks: ["production"],
+  },
+  {
+    id: "accompagnement",
+    title: "Accompagnement continu",
+    description: "Offre fictive pour piloter et maintenir les initiatives IA.",
+    price: "Sur mesure",
+    serviceLinks: ["support", "erp-crm-dev"],
+    solutionLinks: ["services-b2b"],
+  },
+]
+
+export type AeFaqItem = {
+  question: string
+  answer: string
+}
+
+export const faqItems: AeFaqItem[] = [
+  {
+    question: "Comment préparer un cadrage IA ?",
+    answer: "Réponse temporaire renvoyant vers l'audit et la méthode en construction.",
+  },
+  {
+    question: "Quel est le rythme d'un projet pilote ?",
+    answer: "Texte fictif évoquant un déroulé type à préciser bientôt.",
+  },
+  {
+    question: "Comment sont construits les tarifs ?",
+    answer: "Placeholder renvoyant vers les options du catalogue tarifaire.",
+  },
+  {
+    question: "Quelles ressources seront disponibles ?",
+    answer: "Réponse temporaire indiquant la publication progressive des ressources.",
+  },
+]
+
+export const faqAnchors = faqItems.map((item, index) => ({
+  id: `question-${index + 1}`,
+  title: item.question,
+}))
+
+export const anchorScrollMargin = "120px"

--- a/lib/metadata.ts
+++ b/lib/metadata.ts
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
-import { BASE_URL, indexablePaths } from "./site-structure"
+import { BASE_URL } from "./site-structure"
+import { SEO_INDEX_ALL, indexablePaths } from "./ae-content"
 
 type MetadataParams = {
   title: string
@@ -8,9 +9,10 @@ type MetadataParams = {
 }
 
 export const createPageMetadata = ({ title, description, path }: MetadataParams): Metadata => {
-  const allowIndex = process.env.SEO_INDEX_ALL === "true" || indexablePaths.has(path)
+  const allowIndex =
+    process.env.SEO_INDEX_ALL === "true" || SEO_INDEX_ALL || indexablePaths.has(path)
 
-  const metaDescription = description ?? "Contenu à venir."
+  const metaDescription = description ?? "Page en construction."
   const canonical = new URL(path, BASE_URL).toString()
   const isHome = path === "/"
   const fullTitle = `${title} | Aegens`

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -1,66 +1,19 @@
-import { casUsage, sectors, services } from "./site-structure"
+import { footerLegalLinks, plusNavItems } from "./ae-content"
 
 export type NavItem = {
   label: string
   href: string
-  children?: { label: string; href: string }[]
+  children?: NavItem[]
 }
 
+const plusChildren: NavItem[] = plusNavItems.map((item) => ({ ...item }))
+
 export const primaryNav: NavItem[] = [
-  { label: "Accueil", href: "/" },
   { label: "Méthode", href: "/methode" },
-  {
-    label: "Services",
-    href: "/services",
-    children: services.map((service) => ({
-      label: service.title,
-      href: `/services/${service.slug}`,
-    })),
-  },
-  {
-    label: "Cas d'usage",
-    href: "/cas-usage",
-    children: casUsage.map((item) => ({
-      label: item.title,
-      href: `/cas-usage/${item.slug}`,
-    })),
-  },
-  {
-    label: "Secteurs",
-    href: "/secteurs",
-    children: sectors.map((item) => ({
-      label: item.title,
-      href: `/secteurs/${item.slug}`,
-    })),
-  },
-  {
-    label: "Ressources",
-    href: "/ressources",
-    children: [
-      { label: "Blog", href: "/blog" },
-      { label: "Guides", href: "/ressources/guides" },
-      { label: "Question-Hub IA", href: "/ressources/question-hub-ia" },
-      { label: "Comparatifs", href: "/ressources/comparatifs" },
-      { label: "Glossaire", href: "/ressources/glossaire" },
-      { label: "Outils", href: "/ressources/outils" },
-      { label: "Calculateur ROI", href: "/ressources/calculateur-roi" },
-    ],
-  },
+  { label: "Services", href: "/services" },
   { label: "Tarifs", href: "/tarifs" },
-  { label: "FAQ", href: "/faq" },
   { label: "Contact", href: "/contact" },
+  { label: "Plus", href: "#plus", children: plusChildren },
 ]
 
-export const footerLinks = [
-  { label: "Mentions légales", href: "/mentions-legales" },
-  { label: "Politique RGPD", href: "/rgpd" },
-  { label: "Cookies", href: "/cookies" },
-  { label: "DPA", href: "/dpa" },
-  { label: "Conditions générales", href: "/conditions-generales" },
-  { label: "Sitemap", href: "/sitemap" },
-  { label: "Status", href: "/status" },
-  { label: "Changelog", href: "/changelog" },
-  { label: "Contact", href: "/contact" },
-  { label: "Blog", href: "/blog" },
-  { label: "Tarifs", href: "/tarifs" },
-]
+export const footerLinks = footerLegalLinks

--- a/styles/ae-overrides.css
+++ b/styles/ae-overrides.css
@@ -1,0 +1,232 @@
+.ae-dark {
+  color: #fff;
+}
+
+.ae-readable p,
+.ae-readable li,
+.ae-readable small,
+.ae-readable .text-sm {
+  font-size: 1rem;
+  line-height: 1.6;
+  font-weight: 600;
+  color: #fff;
+  letter-spacing: 0.005em;
+}
+
+header nav a {
+  color: #fff;
+  font-weight: 600;
+}
+
+.ae-page-grid {
+  display: grid;
+  gap: 2rem;
+}
+
+@media (min-width: 1024px) {
+  .ae-page-grid {
+    grid-template-columns: minmax(0, 260px) minmax(0, 1fr);
+  }
+}
+
+.ae-toc {
+  position: sticky;
+  top: 6.5rem;
+  display: grid;
+  gap: 0.75rem;
+  padding: 1.5rem;
+  border-radius: 1rem;
+  background: rgba(0, 0, 0, 0.5);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  backdrop-filter: saturate(1.1) blur(10px);
+}
+
+.ae-toc h2 {
+  font-size: 1rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.ae-toc a {
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ae-toc a:focus,
+.ae-toc a:hover {
+  text-decoration: underline;
+  outline: none;
+}
+
+.ae-section {
+  padding: 2.5rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  scroll-margin-top: 120px;
+}
+
+.ae-section:last-of-type {
+  border-bottom: none;
+}
+
+.ae-section h2 {
+  font-size: 1.9rem;
+  font-weight: 700;
+  margin-bottom: 1rem;
+}
+
+.ae-section p {
+  margin-bottom: 1.5rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.ae-section-summary {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.6);
+  margin-bottom: 1.5rem;
+}
+
+.ae-section-links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.ae-section-links a {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.55rem 1rem;
+  border-radius: 9999px;
+  border: 1px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.05);
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ae-section-links a:hover,
+.ae-section-links a:focus {
+  background: rgba(255, 255, 255, 0.15);
+  outline: none;
+}
+
+.ae-dropdown {
+  position: fixed;
+  z-index: 2147483647;
+  display: flex;
+  flex-direction: column;
+  background: rgba(15, 15, 15, 0.92);
+  border-radius: 12px;
+  border: 1px solid rgba(255, 255, 255, 0.12);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.4);
+  backdrop-filter: saturate(1.2) blur(6px);
+  padding: 0.5rem 0;
+}
+
+.ae-dropdown a {
+  display: block;
+  padding: 0.6rem 0.9rem;
+  color: #fff;
+  font-weight: 600;
+  text-decoration: none;
+}
+
+.ae-dropdown a:focus,
+.ae-dropdown a:hover {
+  outline: none;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.ae-breadcrumbs {
+  font-size: 0.875rem;
+  color: rgba(255, 255, 255, 0.6);
+}
+
+.ae-breadcrumbs a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.ae-breadcrumbs a:hover,
+.ae-breadcrumbs a:focus {
+  text-decoration: underline;
+  outline: none;
+}
+
+.ae-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.ae-list li {
+  list-style: none;
+}
+
+.ae-highlight-card {
+  border-radius: 1rem;
+  padding: 1.5rem;
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.ae-highlight-card h3 {
+  font-size: 1.2rem;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+
+.ae-highlight-card p {
+  margin-bottom: 1rem;
+  color: rgba(255, 255, 255, 0.75);
+}
+
+.ae-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+@media (min-width: 768px) {
+  .ae-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 1024px) {
+  .ae-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.ae-notice {
+  font-size: 0.95rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.ae-stack {
+  display: grid;
+  gap: 2rem;
+}
+
+.ae-muted {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.ae-section small {
+  display: block;
+  margin-top: 1rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+main a {
+  color: #fff;
+}
+
+main a:hover,
+main a:focus {
+  text-decoration: underline;
+  outline: none;
+}


### PR DESCRIPTION
## Summary
- centralize Option A navigation, collapsing extra menu entries into the portal-driven Plus dropdown while keeping legal shortcuts
- reworked the header navigation with a portal-mounted “Plus” dropdown and readability overrides so the menu renders above the background while typography becomes larger, brighter, and bolder
- replaced the primary site pages with minimal placeholder sections, anchors, and legal templates aligned with the new Option A navigation structure
- removed the particle system control panel so no configuration window is rendered in production

## Testing
- npm run lint *(fails: ESLint dependency is unavailable in the sandbox)*
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e05bd443308320a964b449f92a32a2